### PR TITLE
Strict input bytes reading

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Psbt.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Psbt.kt
@@ -615,8 +615,8 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
                             val depth = xpub.read()
                             val parent = Pack.int32BE(xpub).toUInt().toLong()
                             val childNumber = Pack.int32BE(xpub).toUInt().toLong()
-                            val chainCode = ByteVector32(xpub.readNBytes(32))
-                            val publicKey = ByteVector(xpub.readNBytes(33))
+                            val chainCode = ByteVector32(xpub.readNBytes(32)!!)
+                            val publicKey = ByteVector(xpub.readNBytes(33)!!)
                             when {
                                 it.value.size() != 4 * (depth + 1) -> return Either.Left(ParseFailure.InvalidExtendedPublicKey("<xpub> must contain the master key fingerprint and derivation path"))
                                 else -> {
@@ -844,11 +844,11 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
             if (input.availableBytes == 0) return Either.Left(ReadEntryFailure.InvalidData)
             val keyLength = BtcSerializer.varint(input).toInt()
             if (keyLength == 0) return Either.Left(ReadEntryFailure.EndOfDataMap)
-            val key = input.readNBytesStrict(keyLength) ?: return Either.Left(ReadEntryFailure.InvalidData)
+            val key = input.readNBytes(keyLength) ?: return Either.Left(ReadEntryFailure.InvalidData)
 
             if (input.availableBytes == 0) return Either.Left(ReadEntryFailure.InvalidData)
             val valueLength = BtcSerializer.varint(input).toInt()
-            val value = input.readNBytesStrict(valueLength) ?: return Either.Left(ReadEntryFailure.InvalidData)
+            val value = input.readNBytes(valueLength) ?: return Either.Left(ReadEntryFailure.InvalidData)
 
             return Either.Right(DataEntry(ByteVector(key), ByteVector(value)))
         }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/Pack.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/Pack.kt
@@ -31,7 +31,7 @@ public object Pack {
     }
 
     @JvmStatic
-    public fun int16BE(input: Input): Short = int16BE(input.readNBytes(Short.SIZE_BYTES))
+    public fun int16BE(input: Input): Short = int16BE(input.readNBytes(Short.SIZE_BYTES) ?: throw IllegalArgumentException("not enough bytes to read from"))
 
     @JvmStatic
     public fun int16LE(bs: ByteArray, off: Int = 0): Short {
@@ -42,7 +42,7 @@ public object Pack {
     }
 
     @JvmStatic
-    public fun int16LE(input: Input): Short = int16LE(input.readNBytes(Short.SIZE_BYTES))
+    public fun int16LE(input: Input): Short = int16LE(input.readNBytes(Short.SIZE_BYTES) ?: throw IllegalArgumentException("not enough bytes to read from"))
 
     @JvmStatic
     public fun writeInt16BE(n: Short, bs: ByteArray, off: Int = 0) {
@@ -85,7 +85,7 @@ public object Pack {
     }
 
     @JvmStatic
-    public fun int32BE(input: Input): Int = int32BE(input.readNBytes(Int.SIZE_BYTES))
+    public fun int32BE(input: Input): Int = int32BE(input.readNBytes(Int.SIZE_BYTES) ?: throw IllegalArgumentException("not enough bytes to read from"))
 
     @JvmStatic
     public fun int32LE(bs: ByteArray, off: Int = 0): Int {
@@ -98,7 +98,7 @@ public object Pack {
     }
 
     @JvmStatic
-    public fun int32LE(input: Input): Int = int32LE(input.readNBytes(Int.SIZE_BYTES))
+    public fun int32LE(input: Input): Int = int32LE(input.readNBytes(Int.SIZE_BYTES) ?: throw IllegalArgumentException("not enough bytes to read from"))
 
     @JvmStatic
     public fun writeInt32BE(n: Int, bs: ByteArray, off: Int = 0) {
@@ -143,7 +143,7 @@ public object Pack {
     }
 
     @JvmStatic
-    public fun int64BE(input: Input): Long = int64BE(input.readNBytes(Long.SIZE_BYTES))
+    public fun int64BE(input: Input): Long = int64BE(input.readNBytes(Long.SIZE_BYTES) ?: throw IllegalArgumentException("not enough bytes to read from"))
 
     @JvmStatic
     public fun int64LE(bs: ByteArray, off: Int = 0): Long {
@@ -154,7 +154,7 @@ public object Pack {
     }
 
     @JvmStatic
-    public fun int64LE(input: Input): Long = int64LE(input.readNBytes(Long.SIZE_BYTES))
+    public fun int64LE(input: Input): Long = int64LE(input.readNBytes(Long.SIZE_BYTES) ?: throw IllegalArgumentException("not enough bytes to read from"))
 
     @JvmStatic
     public fun writeInt64BE(n: Long, bs: ByteArray, off: Int = 0) {

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/io/Input.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/io/Input.kt
@@ -6,5 +6,5 @@ public interface Input {
     public fun read(b: ByteArray, offset: Int = 0, length: Int = b.size - offset): Int
 }
 
-public fun Input.readNBytes(n: Int): ByteArray = ByteArray(n).also { read(it, 0, n) }
-public fun Input.readNBytesStrict(n: Int): ByteArray? = if (availableBytes < n) null else readNBytes(n)
+/** Read bytes from the input. Return null if the input is too small. */
+public fun Input.readNBytes(n: Int): ByteArray? = if (availableBytes < n) null else ByteArray(n).also { read(it, 0, n) }


### PR DESCRIPTION
We always want readNBytes to check whether there are enough bytes before reading to avoid unexpected exceptions.
I'm not sure what to do with the `intXXX` readers that rely on this: should they also return a nullable value instead of throwing?