### PR TITLE
Add hardened derivation leading zeros test

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/bitcoin/DeterministicWalletTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/DeterministicWalletTestsCommon.kt
@@ -120,8 +120,7 @@ class DeterministicWalletTestsCommon {
 
     @Test
     fun `generate and derive keys (test vector #2)`() {
-        val m =
-            DeterministicWallet.generate(Hex.decode("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"))
+        val m = DeterministicWallet.generate(Hex.decode("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"))
         assertEquals(
             DeterministicWallet.encode(m, testnet = false),
             "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U"
@@ -193,8 +192,7 @@ class DeterministicWalletTestsCommon {
 
     @Test
     fun `generate and derive keys (test vector #3)`() {
-        val m =
-            DeterministicWallet.generate(ByteVector("4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be"))
+        val m = DeterministicWallet.generate(ByteVector("4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be"))
         assertEquals(
             DeterministicWallet.encode(m, testnet = false),
             "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6"
@@ -210,6 +208,40 @@ class DeterministicWalletTestsCommon {
         assertEquals(
             DeterministicWallet.encode(DeterministicWallet.publicKey(DeterministicWallet.derivePrivateKey(m, "0'")), testnet = false),
             "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
+        )
+    }
+
+    @Test
+    fun `generate and derive keys (test vector #4)`() {
+        val m = DeterministicWallet.generate(ByteVector("3ddd5602285899a946114506157c7997e5444528f3003f6134712147db19b678"))
+        assertEquals(
+            DeterministicWallet.encode(m, testnet = false),
+            "xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv"
+        )
+        assertEquals(
+            DeterministicWallet.encode(DeterministicWallet.publicKey(m), testnet = false),
+            "xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxyL6tmgBUAEPrEz92mBXjByMRiJdba9wpnN37RLLAXa"
+        )
+
+        val m_0h = DeterministicWallet.derivePrivateKey(m, DeterministicWallet.hardened(0))
+        assertEquals(m_0h.privateKey.value[0], 0) // private key starts with 0x00
+        assertEquals(
+            DeterministicWallet.encode(m_0h, testnet = false),
+            "xprv9vB7xEWwNp9kh1wQRfCCQMnZUEG21LpbR9NPCNN1dwhiZkjjeGRnaALmPXCX7SgjFTiCTT6bXes17boXtjq3xLpcDjzEuGLQBM5ohqkao9G"
+        )
+        assertEquals(
+            DeterministicWallet.encode(DeterministicWallet.publicKey(m_0h), testnet = false),
+            "xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m"
+        )
+
+        val m_0h_1h = DeterministicWallet.derivePrivateKey(m_0h, DeterministicWallet.hardened(1))
+        assertEquals(
+            DeterministicWallet.encode(m_0h_1h, testnet = false),
+            "xprv9xJocDuwtYCMNAo3Zw76WENQeAS6WGXQ55RCy7tDJ8oALr4FWkuVoHJeHVAcAqiZLE7Je3vZJHxspZdFHfnBEjHqU5hG1Jaj32dVoS6XLT1"
+        )
+        assertEquals(
+            DeterministicWallet.encode(DeterministicWallet.publicKey(m_0h_1h), testnet = false),
+            "xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt"
         )
     }
 }


### PR DESCRIPTION
A new test vector was introduced in bitcoin/bips#1030 because some wallets didn't handle leading zeros correctly in
hardened derivation.

We already handled that case correctly, but didn't have a test vector for it.