### PR TITLE
Add support for Bech32m

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a simple Kotlin Multiplatform library which implements most of the bitco
 * BIP 39 (mnemonic code for generating deterministic keys)
 * BIP 173 (Base32 address format for native v0-16 witness outputs)
 * BIP 174 (Partially Signed Bitcoin Transaction Format v0)
+* BIP 350 (Bech32m format)
 
 ## Objectives
 

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Bech32.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Bech32.kt
@@ -19,16 +19,22 @@ package fr.acinq.bitcoin
 import kotlin.jvm.JvmStatic
 
 /**
- * See https://github.com/sipa/bech32/blob/master/bip-witaddr.mediawiki
+ * Bech32 works with 5 bits values, we use this type to make it explicit: whenever you see Int5 it means 5 bits values,
+ * and whenever you see Byte it means 8 bits values.
  */
 public typealias Int5 = Byte
 
+/**
+ * Bech32 and Bech32m address formats.
+ * See https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki and https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki.
+ */
 public object Bech32 {
     public const val alphabet: String = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
-    // 5 bits integer
-    // Bech32 works with 5bits values, we use this type to make it explicit: whenever you see Int5 it means 5bits values, and
-    // whenever you see Byte it means 8bits values
+    public sealed class Encoding {
+        public object Bech32 : Encoding()
+        public object Bech32m : Encoding()
+    }
 
     // char -> 5 bits value
     private val map = Array<Int5>(255) { -1 }
@@ -70,12 +76,25 @@ public object Bech32 {
     }
 
     /**
-     * decodes a bech32 string
-     * @param bech32 bech32 string
-     * @return a (hrp, data) tuple
+     * @param hrp   human readable prefix
+     * @param int5s 5-bit data
+     * @param encoding encoding to use (bech32 or bech32m)
+     * @return hrp + data encoded as a Bech32 string
      */
     @JvmStatic
-    public fun decode(bech32: String): Pair<String, Array<Int5>> {
+    public fun encode(hrp: String, int5s: ByteArray, encoding: Encoding): String {
+        require(hrp.toLowerCase() == hrp || hrp.toUpperCase() == hrp) { "mixed case strings are not valid bech32 prefixes" }
+        val checksum = checksum(hrp, int5s.toTypedArray(), encoding)
+        return hrp + "1" + (int5s.toTypedArray() + checksum).map { i -> alphabet[i.toInt()] }.toCharArray().concatToString()
+    }
+
+    /**
+     * decodes a bech32 string
+     * @param bech32 bech32 string
+     * @return a (hrp, data, encoding) tuple
+     */
+    @JvmStatic
+    public fun decode(bech32: String): Triple<String, Array<Int5>, Encoding> {
         require(bech32.toLowerCase() == bech32 || bech32.toUpperCase() == bech32) { "mixed case strings are not valid bech32" }
         bech32.forEach { require(it.toInt() in 33..126) { "invalid character " } }
 
@@ -85,27 +104,31 @@ public object Bech32 {
         require(hrp.length in 1..83) { "hrp must contain 1 to 83 characters" }
         val data = Array<Int5>(input.length - pos - 1) { 0 }
         for (i in 0..data.lastIndex) data[i] = map[input[pos + 1 + i].toInt()]
-        val checksum = polymod(expand(hrp), data)
-        require(checksum == 1) { "invalid checksum for $bech32" }
-        return Pair(hrp, data.dropLast(6).toTypedArray())
+        val encoding = when (polymod(expand(hrp), data)) {
+            1 -> Encoding.Bech32
+            0x2bc830a3 -> Encoding.Bech32m
+            else -> throw IllegalArgumentException("invalid checksum for $bech32")
+        }
+        return Triple(hrp, data.dropLast(6).toTypedArray(), encoding)
     }
 
     /**
-     *
      * @param hrp Human Readable Part
      * @param data data (a sequence of 5 bits integers)
+     * @param encoding encoding to use (bech32 or bech32m)
      * @return a checksum computed over hrp and data
      */
-    private fun checksum(hrp: String, data: Array<Int5>): Array<Int5> {
+    private fun checksum(hrp: String, data: Array<Int5>, encoding: Encoding): Array<Int5> {
+        val constant = when (encoding) {
+            Encoding.Bech32 -> 1
+            Encoding.Bech32m -> 0x2bc830a3
+        }
         val values = expand(hrp) + data
-        val poly =
-            polymod(values, arrayOf(0.toByte(), 0.toByte(), 0.toByte(), 0.toByte(), 0.toByte(), 0.toByte())) xor 1
-        val result = Array(6) { i -> (poly.shr(5 * (5 - i)) and 31).toByte() }
-        return result
+        val poly = polymod(values, arrayOf(0.toByte(), 0.toByte(), 0.toByte(), 0.toByte(), 0.toByte(), 0.toByte())) xor constant
+        return Array(6) { i -> (poly.shr(5 * (5 - i)) and 31).toByte() }
     }
 
     /**
-     *
      * @param input a sequence of 8 bits integers
      * @return a sequence of 5 bits integers
      */
@@ -127,7 +150,6 @@ public object Bech32 {
     }
 
     /**
-     *
      * @param input a sequence of 5 bits integers
      * @return a sequence of 8 bits integers
      */
@@ -153,15 +175,19 @@ public object Bech32 {
     /**
      * encode a bitcoin witness address
      * @param hrp should be "bc" or "tb"
-     * @param witnessVersion witness version (0 to 16, only 0 is currently defined)
+     * @param witnessVersion witness version (0 to 16)
      * @param data witness program: if version is 0, either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
      * @return a bech32 encoded witness address
      */
     @JvmStatic
     public fun encodeWitnessAddress(hrp: String, witnessVersion: Byte, data: ByteArray): String {
-        // prepend witness version: 0
+        require(witnessVersion in 0..16) { "invalid segwit version" }
+        val encoding = when (witnessVersion) {
+            0.toByte() -> Encoding.Bech32
+            else -> Encoding.Bech32m
+        }
         val data1 = arrayOf(witnessVersion) + eight2five(data)
-        val checksum = checksum(hrp, data1)
+        val checksum = checksum(hrp, data1, encoding)
         val chars = (data1 + checksum).map { i -> alphabet[i.toInt()] }
         val sb = StringBuilder()
         for (c in chars) sb.append(c)
@@ -171,31 +197,21 @@ public object Bech32 {
     /**
      * decode a bitcoin witness address
      * @param address witness address
-     * @return a (version, program) tuple where version is the witness version and program the decoded witness program.
-     *         If version is 0, it will be either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
+     * @return a (prefix, version, program) tuple where prefix is the human-readable prefix, version is the witness version and program the decoded witness program.
+     *         If version is 0, it will be either 20 bytes (P2WPKH) or 32 bytes (P2WSH).
      */
     @JvmStatic
     public fun decodeWitnessAddress(address: String): Triple<String, Byte, ByteArray> {
-        val (hrp, data) = decode(address)
+        val (hrp, data, encoding) = decode(address)
         require(hrp == "bc" || hrp == "tb" || hrp == "bcrt") { "invalid HRP $hrp" }
         val version = data[0]
         require(version in 0..16) { "invalid segwit version" }
         val bin = five2eight(data, 1)
         require(bin.size in 2..40) { "invalid witness program length ${bin.size}" }
+        if (version == 0.toByte()) require(encoding == Encoding.Bech32) { "version 0 must be encoded with Bech32" }
         if (version == 0.toByte()) require(bin.size == 20 || bin.size == 32) { "invalid witness program length ${bin.size}" }
+        if (version != 0.toByte()) require(encoding == Encoding.Bech32m) { "version 1 to 16 must be encoded with Bech32m" }
         return Triple(hrp, version, bin)
     }
 
-    /**
-     *
-     * @param hrp   human readable prefix
-     * @param int5s 5-bit data
-     * @return hrp + data encoded as a Bech32 string
-     */
-    @JvmStatic
-    public fun encode(hrp: String, int5s: ByteArray): String {
-        require(hrp.toLowerCase() == hrp || hrp.toUpperCase() == hrp) { "mixed case strings are not valid bech32 prefixes" }
-        val checksum = checksum(hrp, int5s.toTypedArray())
-        return hrp + "1" + (int5s.toTypedArray() + checksum).map { i -> alphabet[i.toInt()] }.toCharArray().concatToString()
-    }
 }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/Bech32TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/Bech32TestsCommon.kt
@@ -23,23 +23,33 @@ import kotlin.test.assertFails
 
 class Bech32TestsCommon {
     @Test
-    fun `valid`() {
+    fun `valid checksums`() {
         val inputs = listOf(
+            // Bech32
             "A12UEL5L",
             "a12uel5l",
             "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
             "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
             "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
             "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
-            "?1ezyfcl"
+            "?1ezyfcl",
+            // Bech32m
+            "A1LQFN3A",
+            "a1lqfn3a",
+            "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6",
+            "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx",
+            "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8",
+            "split1checkupstagehandshakeupstreamerranterredcaperredlc445v",
+            "?1v759aa",
         )
         val outputs = inputs.map(Bech32::decode)
         assertEquals(outputs.size, inputs.size)
     }
 
     @Test
-    fun `invalid`() {
+    fun `invalid checksums`() {
         val inputs = listOf(
+            // Bech32
             " 1nwldj5",
             "\u007f1axkwrx",
             "\u00801eym55h",
@@ -51,11 +61,26 @@ class Bech32TestsCommon {
             "de1lg7wt\u00ff",
             "A1G7SGD8",
             "10a06t8",
-            "1qzzfhee"
+            "1qzzfhee",
+            // Bech32m
+            "\u00201xj0phk",
+            "\u007F1g6xzxy",
+            "\u00801vctc34",
+            "an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
+            "qyrz8wqd2c9m",
+            "1qyrz8wqd2c9m",
+            "y1b0jsk6g",
+            "lt1igcx5c0",
+            "in1muywd",
+            "mm1crxm3i",
+            "au1s5cgom",
+            "M1VUXWEZ",
+            "16plkw9",
+            "1p2gdwpf"
         )
         inputs.forEach {
             assertFails {
-                println(Bech32.decodeWitnessAddress(it))
+                Bech32.decodeWitnessAddress(it)
             }
         }
     }
@@ -65,10 +90,12 @@ class Bech32TestsCommon {
         val inputs = listOf(
             "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4" to "0014751e76e8199196d454941c45d1b3a323f1433bd6",
             "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7" to "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-            "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx" to "8128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
-            "BC1SW50QA3JX3S" to "9002751e",
-            "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj" to "8210751e76e8199196d454941c45d1b3a323",
-            "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy" to "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"
+            "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y" to "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+            "BC1SW50QGDZ25J" to "6002751e",
+            "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs" to "5210751e76e8199196d454941c45d1b3a323",
+            "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy" to "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+            "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c" to "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0" to "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
         )
         inputs.forEach {
             val (_, _, bin1) = Bech32.decodeWitnessAddress(it.first)
@@ -79,13 +106,16 @@ class Bech32TestsCommon {
     @Test
     fun `create addresses`() {
         assertEquals(Bech32.encodeWitnessAddress("bc", 0, Hex.decode("751e76e8199196d454941c45d1b3a323f1433bd6")), "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4".toLowerCase())
+        assertEquals(Bech32.encodeWitnessAddress("bc", 1, Hex.decode("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")), "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0")
         assertEquals(Bech32.encodeWitnessAddress("tb", 0, Hex.decode("1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262")), "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
         assertEquals(Bech32.encodeWitnessAddress("tb", 0, Hex.decode("000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433")), "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy")
+        assertEquals(Bech32.encodeWitnessAddress("tb", 1, Hex.decode("000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433")), "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c")
     }
 
     @Test
     fun `reject invalid addresses`() {
         val addresses = listOf(
+            // Bech32
             "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
             "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
             "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
@@ -97,7 +127,22 @@ class Bech32TestsCommon {
             "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
             "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
             "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
-            "bc1gmk9yu"
+            "bc1gmk9yu",
+            // Bech32m
+            "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
+            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
+            "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
+            "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL",
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh",
+            "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
+            "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
+            "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
+            "bc1pw5dgrnzv",
+            "bc1pw5dgrnzv",
+            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
+            "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
+            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
+            "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
         )
         addresses.forEach {
             assertFails {

--- a/src/commonTest/resources/data/key_io_valid.json
+++ b/src/commonTest/resources/data/key_io_valid.json
@@ -486,7 +486,7 @@
         }
     ],
     [
-        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
         "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
         {
             "isPrivkey": false,
@@ -495,7 +495,7 @@
         }
     ],
     [
-        "bc1sw50qa3jx3s",
+        "bc1sw50qgdz25j",
         "6002751e",
         {
             "isPrivkey": false,
@@ -504,7 +504,7 @@
         }
     ],
     [
-        "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
+        "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs",
         "5210751e76e8199196d454941c45d1b3a323",
         {
             "isPrivkey": false,


### PR DESCRIPTION
This support will be necessary for future P2TR addresses.
We add forward-compatible support for segwit v1-16 as suggested in [BIP 350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).