### PR TITLE
Improve PSBT types

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Psbt.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Psbt.kt
@@ -29,7 +29,7 @@ import fr.acinq.bitcoin.utils.getOrElse
  * @param outputs signing data for each output of the transaction to be signed (order matches the unsigned tx).
  */
 @OptIn(ExperimentalUnsignedTypes::class)
-public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput>, val outputs: List<PartiallySignedOutput>) {
+public data class Psbt(val global: Global, val inputs: List<Input>, val outputs: List<Output>) {
 
     init {
         require(global.tx.txIn.size == inputs.size) { "there must be one partially signed input per input of the unsigned tx" }
@@ -44,23 +44,75 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
      */
     public constructor(tx: Transaction) : this(
         Global(Version, tx.copy(txIn = tx.txIn.map { it.copy(signatureScript = ByteVector.empty, witness = ScriptWitness.empty) }), listOf(), listOf()),
-        tx.txIn.map { PartiallySignedInput.empty },
-        tx.txOut.map { PartiallySignedOutput.empty }
+        tx.txIn.map { Input.PartiallySignedInputWithoutUtxo(null, mapOf(), setOf(), setOf(), setOf(), setOf(), listOf()) },
+        tx.txOut.map { Output.UnspecifiedOutput(mapOf(), listOf()) }
     )
 
     /**
-     * Implements the PSBT updater role; adds information about a given UTXO.
-     * Note that we always fill the nonWitnessUtxo (see https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#cite_note-7).
+     * Implements the PSBT updater role; adds information about a given segwit utxo.
+     * When you have access to the complete input transaction, you should prefer [[updateWitnessInputTx]].
      *
-     * @param inputTx transaction containing the UTXO.
-     * @param outputIndex index of the UTXO in the inputTx.
-     * @param redeemScript redeem script if known and applicable.
-     * @param witnessScript witness script if known and applicable.
+     * @param outPoint utxo being spent.
+     * @param txOut transaction output for the provided outPoint.
+     * @param redeemScript redeem script if known and applicable (when using p2sh-embedded segwit).
+     * @param witnessScript witness script if known and applicable (when using p2wsh).
      * @param sighashType sighash type if one should be specified.
-     * @param derivationPaths derivation paths for keys used by this UTXO.
+     * @param derivationPaths derivation paths for keys used by this utxo.
      * @return psbt with the matching input updated.
      */
-    public fun update(
+    public fun updateWitnessInput(
+        outPoint: OutPoint,
+        txOut: TxOut,
+        redeemScript: List<ScriptElt>? = null,
+        witnessScript: List<ScriptElt>? = null,
+        sighashType: Int? = null,
+        derivationPaths: Map<PublicKey, KeyPathWithMaster> = mapOf()
+    ): Either<UpdateFailure, Psbt> {
+        val inputIndex = global.tx.txIn.indexOfFirst { it.outPoint == outPoint }
+        if (inputIndex < 0) return Either.Left(UpdateFailure.InvalidInput("psbt transaction does not spend the provided outpoint"))
+        val updatedInput = when (val input = inputs[inputIndex]) {
+            is Input.PartiallySignedInputWithoutUtxo -> Input.WitnessInput.PartiallySignedWitnessInput(
+                txOut,
+                null,
+                sighashType ?: input.sighashType,
+                mapOf(),
+                derivationPaths + input.derivationPaths,
+                redeemScript,
+                witnessScript,
+                input.ripemd160,
+                input.sha256,
+                input.hash160,
+                input.hash256,
+                input.unknown
+            )
+            is Input.WitnessInput.PartiallySignedWitnessInput -> input.copy(
+                txOut = txOut,
+                redeemScript = redeemScript ?: input.redeemScript,
+                witnessScript = witnessScript ?: input.witnessScript,
+                sighashType = sighashType ?: input.sighashType,
+                derivationPaths = input.derivationPaths + derivationPaths
+            )
+            is Input.NonWitnessInput.PartiallySignedNonWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update segwit input: it has already been updated with non-segwit data"))
+            is Input.FinalizedInputWithoutUtxo -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update segwit input: it has already been finalized"))
+            is Input.WitnessInput.FinalizedWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update segwit input: it has already been finalized"))
+            is Input.NonWitnessInput.FinalizedNonWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update segwit input: it has already been finalized"))
+        }
+        return Either.Right(this.copy(inputs = inputs.updated(inputIndex, updatedInput)))
+    }
+
+    /**
+     * Implements the PSBT updater role; adds information about a given segwit utxo.
+     * Note that we always fill the nonWitnessUtxo (see https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#cite_note-7).
+     *
+     * @param inputTx transaction containing the utxo.
+     * @param outputIndex index of the utxo in the inputTx.
+     * @param redeemScript redeem script if known and applicable (when using p2sh-embedded segwit).
+     * @param witnessScript witness script if known and applicable (when using p2wsh).
+     * @param sighashType sighash type if one should be specified.
+     * @param derivationPaths derivation paths for keys used by this utxo.
+     * @return psbt with the matching input updated.
+     */
+    public fun updateWitnessInputTx(
         inputTx: Transaction,
         outputIndex: Int,
         redeemScript: List<ScriptElt>? = null,
@@ -72,24 +124,172 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
         val outpoint = OutPoint(inputTx, outputIndex.toLong())
         val inputIndex = global.tx.txIn.indexOfFirst { it.outPoint == outpoint }
         if (inputIndex < 0) return Either.Left(UpdateFailure.InvalidInput("psbt transaction does not spend the provided outpoint"))
-        val input = inputs[inputIndex]
-        val updated = when {
-            witnessScript != null -> input.copy(
-                witnessUtxo = inputTx.txOut[outputIndex],
-                witnessScript = witnessScript,
+        val updatedInput = when (val input = inputs[inputIndex]) {
+            is Input.PartiallySignedInputWithoutUtxo -> Input.WitnessInput.PartiallySignedWitnessInput(
+                inputTx.txOut[outputIndex],
+                inputTx,
+                sighashType ?: input.sighashType,
+                mapOf(),
+                derivationPaths + input.derivationPaths,
+                redeemScript,
+                witnessScript,
+                input.ripemd160,
+                input.sha256,
+                input.hash160,
+                input.hash256,
+                input.unknown
+            )
+            is Input.WitnessInput.PartiallySignedWitnessInput -> input.copy(
+                txOut = inputTx.txOut[outputIndex],
                 nonWitnessUtxo = inputTx,
                 redeemScript = redeemScript ?: input.redeemScript,
+                witnessScript = witnessScript ?: input.witnessScript,
                 sighashType = sighashType ?: input.sighashType,
                 derivationPaths = input.derivationPaths + derivationPaths
             )
-            else -> input.copy(
-                nonWitnessUtxo = inputTx,
-                redeemScript = redeemScript ?: input.redeemScript,
-                sighashType = sighashType ?: input.sighashType,
-                derivationPaths = input.derivationPaths + derivationPaths
-            )
+            is Input.NonWitnessInput.PartiallySignedNonWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update segwit input: it has already been updated with non-segwit data"))
+            is Input.FinalizedInputWithoutUtxo -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update segwit input: it has already been finalized"))
+            is Input.WitnessInput.FinalizedWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update segwit input: it has already been finalized"))
+            is Input.NonWitnessInput.FinalizedNonWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update segwit input: it has already been finalized"))
         }
-        return Either.Right(this.copy(inputs = inputs.updated(inputIndex, updated)))
+        return Either.Right(this.copy(inputs = inputs.updated(inputIndex, updatedInput)))
+    }
+
+    /**
+     * Implements the PSBT updater role; adds information about a given non-segwit utxo.
+     *
+     * @param inputTx transaction containing the utxo.
+     * @param outputIndex index of the utxo in the inputTx.
+     * @param redeemScript redeem script if known and applicable (when using p2sh).
+     * @param sighashType sighash type if one should be specified.
+     * @param derivationPaths derivation paths for keys used by this utxo.
+     * @return psbt with the matching input updated.
+     */
+    public fun updateNonWitnessInput(
+        inputTx: Transaction,
+        outputIndex: Int,
+        redeemScript: List<ScriptElt>? = null,
+        sighashType: Int? = null,
+        derivationPaths: Map<PublicKey, KeyPathWithMaster> = mapOf()
+    ): Either<UpdateFailure, Psbt> {
+        if (outputIndex >= inputTx.txOut.size) return Either.Left(UpdateFailure.InvalidInput("output index must exist in the input tx"))
+        val outpoint = OutPoint(inputTx, outputIndex.toLong())
+        val inputIndex = global.tx.txIn.indexOfFirst { it.outPoint == outpoint }
+        if (inputIndex < 0) return Either.Left(UpdateFailure.InvalidInput("psbt transaction does not spend the provided outpoint"))
+        val updatedInput = when (val input = inputs[inputIndex]) {
+            is Input.PartiallySignedInputWithoutUtxo -> Input.NonWitnessInput.PartiallySignedNonWitnessInput(
+                inputTx,
+                outputIndex,
+                sighashType ?: input.sighashType,
+                mapOf(),
+                derivationPaths + input.derivationPaths,
+                redeemScript,
+                input.ripemd160,
+                input.sha256,
+                input.hash160,
+                input.hash256,
+                input.unknown
+            )
+            is Input.NonWitnessInput.PartiallySignedNonWitnessInput -> input.copy(
+                inputTx = inputTx,
+                outputIndex = outputIndex,
+                redeemScript = redeemScript ?: input.redeemScript,
+                sighashType = sighashType ?: input.sighashType,
+                derivationPaths = input.derivationPaths + derivationPaths
+            )
+            is Input.WitnessInput.PartiallySignedWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update non-segwit input: it has already been updated with segwit data"))
+            is Input.FinalizedInputWithoutUtxo -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update non-segwit input: it has already been finalized"))
+            is Input.WitnessInput.FinalizedWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update non-segwit input: it has already been finalized"))
+            is Input.NonWitnessInput.FinalizedNonWitnessInput -> return Either.Left(UpdateFailure.CannotUpdateInput(inputIndex, "cannot update non-segwit input: it has already been finalized"))
+        }
+        return Either.Right(this.copy(inputs = inputs.updated(inputIndex, updatedInput)))
+    }
+
+    public fun updatePreimageChallenges(outPoint: OutPoint, ripemd160: Set<ByteVector>, sha256: Set<ByteVector>, hash160: Set<ByteVector>, hash256: Set<ByteVector>): Either<UpdateFailure, Psbt> {
+        val inputIndex = global.tx.txIn.indexOfFirst { it.outPoint == outPoint }
+        if (inputIndex < 0) return Either.Left(UpdateFailure.InvalidInput("psbt transaction does not spend the provided outpoint"))
+        return updatePreimageChallenges(inputIndex, ripemd160, sha256, hash160, hash256)
+    }
+
+    public fun updatePreimageChallenges(inputIndex: Int, ripemd160: Set<ByteVector>, sha256: Set<ByteVector>, hash160: Set<ByteVector>, hash256: Set<ByteVector>): Either<UpdateFailure, Psbt> {
+        if (inputIndex >= inputs.size) return Either.Left(UpdateFailure.InvalidInput("input index must exist in the input tx"))
+        val updatedInput = when (val input = inputs[inputIndex]) {
+            is Input.PartiallySignedInputWithoutUtxo -> input.copy(ripemd160 = ripemd160 + input.ripemd160, sha256 = sha256 + input.sha256, hash160 = hash160 + input.hash160, hash256 = hash256 + input.hash256)
+            is Input.WitnessInput.PartiallySignedWitnessInput -> input.copy(ripemd160 = ripemd160 + input.ripemd160, sha256 = sha256 + input.sha256, hash160 = hash160 + input.hash160, hash256 = hash256 + input.hash256)
+            is Input.NonWitnessInput.PartiallySignedNonWitnessInput -> input.copy(ripemd160 = ripemd160 + input.ripemd160, sha256 = sha256 + input.sha256, hash160 = hash160 + input.hash160, hash256 = hash256 + input.hash256)
+            is Input.WitnessInput.FinalizedWitnessInput -> input.copy(ripemd160 = ripemd160 + input.ripemd160, sha256 = sha256 + input.sha256, hash160 = hash160 + input.hash160, hash256 = hash256 + input.hash256)
+            is Input.NonWitnessInput.FinalizedNonWitnessInput -> input.copy(ripemd160 = ripemd160 + input.ripemd160, sha256 = sha256 + input.sha256, hash160 = hash160 + input.hash160, hash256 = hash256 + input.hash256)
+            is Input.FinalizedInputWithoutUtxo -> input.copy(ripemd160 = ripemd160 + input.ripemd160, sha256 = sha256 + input.sha256, hash160 = hash160 + input.hash160, hash256 = hash256 + input.hash256)
+        }
+        return Either.Right(this.copy(inputs = inputs.updated(inputIndex, updatedInput)))
+    }
+
+    /**
+     * Add details for a segwit output.
+     *
+     * @param outputIndex index of the output in the psbt.
+     * @param witnessScript witness script if known and applicable (when using p2wsh).
+     * @param redeemScript redeem script if known and applicable (when using p2sh-embedded segwit).
+     * @param derivationPaths derivation paths for keys used by this output.
+     * @return psbt with the matching output updated.
+     */
+    public fun updateWitnessOutput(
+        outputIndex: Int,
+        witnessScript: List<ScriptElt>? = null,
+        redeemScript: List<ScriptElt>? = null,
+        derivationPaths: Map<PublicKey, KeyPathWithMaster> = mapOf()
+    ): Either<UpdateFailure, Psbt> {
+        if (outputIndex >= global.tx.txOut.size) return Either.Left(UpdateFailure.InvalidInput("output index must exist in the global tx"))
+        val updatedOutput = when (val output = outputs[outputIndex]) {
+            is Output.NonWitnessOutput -> return Either.Left(UpdateFailure.CannotUpdateOutput(outputIndex, "cannot update segwit output: it has already been updated with non-segwit data"))
+            is Output.WitnessOutput -> output.copy(
+                witnessScript = witnessScript ?: output.witnessScript,
+                redeemScript = redeemScript ?: output.redeemScript,
+                derivationPaths = derivationPaths + output.derivationPaths
+            )
+            is Output.UnspecifiedOutput -> Output.WitnessOutput(witnessScript, redeemScript, derivationPaths + output.derivationPaths, output.unknown)
+        }
+        return Either.Right(this.copy(outputs = outputs.updated(outputIndex, updatedOutput)))
+    }
+
+    /**
+     * Add details for a non-segwit output.
+     *
+     * @param outputIndex index of the output in the psbt.
+     * @param redeemScript redeem script if known and applicable (when using p2sh).
+     * @param derivationPaths derivation paths for keys used by this output.
+     * @return psbt with the matching output updated.
+     */
+    public fun updateNonWitnessOutput(
+        outputIndex: Int,
+        redeemScript: List<ScriptElt>? = null,
+        derivationPaths: Map<PublicKey, KeyPathWithMaster> = mapOf()
+    ): Either<UpdateFailure, Psbt> {
+        if (outputIndex >= global.tx.txOut.size) return Either.Left(UpdateFailure.InvalidInput("output index must exist in the global tx"))
+        val updatedOutput = when (val output = outputs[outputIndex]) {
+            is Output.NonWitnessOutput -> output.copy(
+                redeemScript = redeemScript ?: output.redeemScript,
+                derivationPaths = derivationPaths + output.derivationPaths
+            )
+            is Output.WitnessOutput -> return Either.Left(UpdateFailure.CannotUpdateOutput(outputIndex, "cannot update non-segwit output: it has already been updated with segwit data"))
+            is Output.UnspecifiedOutput -> Output.NonWitnessOutput(redeemScript, derivationPaths + output.derivationPaths, output.unknown)
+        }
+        return Either.Right(this.copy(outputs = outputs.updated(outputIndex, updatedOutput)))
+    }
+
+    /**
+     * Implements the PSBT signer role: sign a given input.
+     * The caller needs to carefully verify that it wants to spend that input, and that the unsigned transaction matches
+     * what it expects.
+     *
+     * @param priv private key used to sign the input.
+     * @param outPoint input that should be signed.
+     * @return the psbt with a partial signature added (other inputs will not be modified).
+     */
+    public fun sign(priv: PrivateKey, outPoint: OutPoint): Either<UpdateFailure, SignPsbtResult> {
+        val inputIndex = global.tx.txIn.indexOfFirst { it.outPoint == outPoint }
+        if (inputIndex < 0) return Either.Left(UpdateFailure.InvalidInput("psbt transaction does not spend the provided outpoint"))
+        return sign(priv, inputIndex)
     }
 
     /**
@@ -101,115 +301,166 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
      * @param inputIndex index of the input that should be signed.
      * @return the psbt with a partial signature added (other inputs will not be modified).
      */
-    public fun sign(priv: PrivateKey, inputIndex: Int): Either<UpdateFailure, Psbt> {
+    public fun sign(priv: PrivateKey, inputIndex: Int): Either<UpdateFailure, SignPsbtResult> {
         if (inputIndex >= inputs.size) return Either.Left(UpdateFailure.InvalidInput("input index must exist in the input tx"))
         val input = inputs[inputIndex]
+        return sign(priv, inputIndex, input, global).map { SignPsbtResult(this.copy(inputs = inputs.updated(inputIndex, it.first)), it.second) }
+    }
+
+    private fun sign(priv: PrivateKey, inputIndex: Int, input: Input, global: Global): Either<UpdateFailure, Pair<Input, ByteVector>> {
         val txIn = global.tx.txIn[inputIndex]
-        return when {
-            input.nonWitnessUtxo != null && input.nonWitnessUtxo.txid != txIn.outPoint.txid -> Either.Left(UpdateFailure.InvalidNonWitnessUtxo("non-witness utxo does not match unsigned tx input"))
-            input.nonWitnessUtxo != null && input.nonWitnessUtxo.txOut.size <= txIn.outPoint.index -> Either.Left(UpdateFailure.InvalidNonWitnessUtxo("non-witness utxo index out of bounds"))
-            input.witnessUtxo != null && !Script.isNativeWitnessScript(input.witnessUtxo.publicKeyScript) && !Script.isPayToScript(input.witnessUtxo.publicKeyScript.bytes) -> Either.Left(UpdateFailure.InvalidWitnessUtxo("witness utxo must use native witness program or P2SH witness program"))
-            input.witnessUtxo != null -> {
-                val utxo = input.witnessUtxo
-                val redeemScript = when {
-                    input.redeemScript != null -> {
-                        // If a redeem script is provided in the partially signed input, the utxo must be a p2sh for that script.
-                        val p2sh = Script.write(Script.pay2sh(input.redeemScript))
-                        if (!utxo.publicKeyScript.contentEquals(p2sh)) {
-                            return Either.Left(UpdateFailure.InvalidWitnessUtxo("redeem script does not match witness utxo scriptPubKey"))
-                        }
-                        input.redeemScript
-                    }
-                    else -> runCatching { Script.parse(utxo.publicKeyScript) }.getOrElse { return Either.Left(UpdateFailure.InvalidWitnessUtxo("failed to parse redeem script")) }
+        return when (input) {
+            is Input.PartiallySignedInputWithoutUtxo -> Either.Left(UpdateFailure.CannotSignInput(inputIndex, "cannot sign: input hasn't been updated with utxo data"))
+            is Input.WitnessInput.PartiallySignedWitnessInput -> {
+                if (input.nonWitnessUtxo != null && input.nonWitnessUtxo!!.txid != txIn.outPoint.txid) {
+                    Either.Left(UpdateFailure.InvalidNonWitnessUtxo("non-witness utxo does not match unsigned tx input"))
+                } else if (input.nonWitnessUtxo != null && input.nonWitnessUtxo!!.txOut.size <= txIn.outPoint.index) {
+                    Either.Left(UpdateFailure.InvalidNonWitnessUtxo("non-witness utxo index out of bounds"))
+                } else if (!Script.isNativeWitnessScript(input.txOut.publicKeyScript) && !Script.isPayToScript(input.txOut.publicKeyScript.toByteArray())) {
+                    Either.Left(UpdateFailure.InvalidWitnessUtxo("witness utxo must use native segwit or P2SH embedded segwit"))
+                } else {
+                    signWitness(priv, inputIndex, input, global)
                 }
-                val sig = when {
-                    input.witnessScript != null && !Script.isPay2wpkh(redeemScript) && redeemScript != Script.pay2wsh(input.witnessScript) -> return Either.Left(UpdateFailure.InvalidWitnessUtxo("witness script does not match redeemScript or scriptPubKey"))
-                    input.witnessScript != null -> Transaction.signInput(global.tx, inputIndex, input.witnessScript, input.sighashType ?: SigHash.SIGHASH_ALL, utxo.amount, SigVersion.SIGVERSION_WITNESS_V0, priv)
-                    else -> Transaction.signInput(global.tx, inputIndex, redeemScript, input.sighashType ?: SigHash.SIGHASH_ALL, utxo.amount, SigVersion.SIGVERSION_WITNESS_V0, priv)
-                }
-                Either.Right(this.copy(inputs = this.inputs.updated(inputIndex, input.copy(partialSigs = input.partialSigs + (priv.publicKey() to ByteVector(sig))))))
             }
-            input.nonWitnessUtxo != null -> {
-                val utxo = input.nonWitnessUtxo
-                val redeemScript = when {
-                    input.redeemScript != null -> {
-                        // If a redeem script is provided in the partially signed input, the utxo must be a p2sh for that script.
-                        val p2sh = Script.write(Script.pay2sh(input.redeemScript))
-                        if (!utxo.txOut[txIn.outPoint.index.toInt()].publicKeyScript.contentEquals(p2sh)) {
-                            return Either.Left(UpdateFailure.InvalidNonWitnessUtxo("redeem script does not match non-witness utxo scriptPubKey"))
-                        }
-                        input.redeemScript
-                    }
-                    else -> runCatching { Script.parse(utxo.txOut[txIn.outPoint.index.toInt()].publicKeyScript) }.getOrElse { return Either.Left(UpdateFailure.InvalidNonWitnessUtxo("failed to parse redeem script")) }
+            is Input.NonWitnessInput.PartiallySignedNonWitnessInput -> {
+                if (input.inputTx.txid != txIn.outPoint.txid) {
+                    Either.Left(UpdateFailure.InvalidNonWitnessUtxo("non-witness utxo does not match unsigned tx input"))
+                } else if (input.inputTx.txOut.size <= txIn.outPoint.index) {
+                    Either.Left(UpdateFailure.InvalidNonWitnessUtxo("non-witness utxo index out of bounds"))
+                } else {
+                    signNonWitness(priv, inputIndex, input, global)
                 }
-                val amount = utxo.txOut[txIn.outPoint.index.toInt()].amount
-                val sig = Transaction.signInput(global.tx, inputIndex, redeemScript, input.sighashType ?: SigHash.SIGHASH_ALL, amount, SigVersion.SIGVERSION_BASE, priv)
-                Either.Right(this.copy(inputs = this.inputs.updated(inputIndex, input.copy(partialSigs = input.partialSigs + (priv.publicKey() to ByteVector(sig))))))
             }
-            else -> Either.Right(this) // nothing to sign
+            is Input.FinalizedInputWithoutUtxo -> Either.Left(UpdateFailure.CannotSignInput(inputIndex, "cannot sign: input has already been finalized"))
+            is Input.WitnessInput.FinalizedWitnessInput -> Either.Left(UpdateFailure.CannotSignInput(inputIndex, "cannot sign: input has already been finalized"))
+            is Input.NonWitnessInput.FinalizedNonWitnessInput -> Either.Left(UpdateFailure.CannotSignInput(inputIndex, "cannot sign: input has already been finalized"))
+
+        }
+    }
+
+    private fun signNonWitness(priv: PrivateKey, inputIndex: Int, input: Input.NonWitnessInput.PartiallySignedNonWitnessInput, global: Global): Either<UpdateFailure, Pair<Input.NonWitnessInput.PartiallySignedNonWitnessInput, ByteVector>> {
+        val txIn = global.tx.txIn[inputIndex]
+        val redeemScript = when (input.redeemScript) {
+            null -> runCatching {
+                Script.parse(input.inputTx.txOut[txIn.outPoint.index.toInt()].publicKeyScript)
+            }.getOrElse {
+                return Either.Left(UpdateFailure.InvalidNonWitnessUtxo("failed to parse redeem script"))
+            }
+            else -> {
+                // If a redeem script is provided in the partially signed input, the utxo must be a p2sh for that script.
+                val p2sh = Script.write(Script.pay2sh(input.redeemScript))
+                if (!input.inputTx.txOut[txIn.outPoint.index.toInt()].publicKeyScript.contentEquals(p2sh)) {
+                    return Either.Left(UpdateFailure.InvalidNonWitnessUtxo("redeem script does not match non-witness utxo scriptPubKey"))
+                } else {
+                    input.redeemScript
+                }
+            }
+        }
+        val sig = ByteVector(Transaction.signInput(global.tx, inputIndex, redeemScript, input.sighashType ?: SigHash.SIGHASH_ALL, input.amount, SigVersion.SIGVERSION_BASE, priv))
+        return Either.Right(Pair(input.copy(partialSigs = input.partialSigs + (priv.publicKey() to sig)), sig))
+    }
+
+    private fun signWitness(priv: PrivateKey, inputIndex: Int, input: Input.WitnessInput.PartiallySignedWitnessInput, global: Global): Either<UpdateFailure, Pair<Input.WitnessInput.PartiallySignedWitnessInput, ByteVector>> {
+        val redeemScript = when (input.redeemScript) {
+            null -> runCatching {
+                Script.parse(input.txOut.publicKeyScript)
+            }.getOrElse {
+                return Either.Left(UpdateFailure.InvalidWitnessUtxo("failed to parse redeem script"))
+            }
+            else -> {
+                // If a redeem script is provided in the partially signed input, the utxo must be a p2sh for that script (we're using p2sh-embedded segwit).
+                val p2sh = Script.write(Script.pay2sh(input.redeemScript))
+                if (!input.txOut.publicKeyScript.contentEquals(p2sh)) {
+                    return Either.Left(UpdateFailure.InvalidWitnessUtxo("redeem script does not match witness utxo scriptPubKey"))
+                } else {
+                    input.redeemScript
+                }
+            }
+        }
+        return when (input.witnessScript) {
+            null -> {
+                val sig = ByteVector(Transaction.signInput(global.tx, inputIndex, redeemScript, input.sighashType ?: SigHash.SIGHASH_ALL, input.amount, SigVersion.SIGVERSION_WITNESS_V0, priv))
+                Either.Right(Pair(input.copy(partialSigs = input.partialSigs + (priv.publicKey() to sig)), sig))
+            }
+            else -> {
+                if (!Script.isPay2wpkh(redeemScript) && redeemScript != Script.pay2wsh(input.witnessScript)) {
+                    Either.Left(UpdateFailure.InvalidWitnessUtxo("witness script does not match redeemScript or scriptPubKey"))
+                } else {
+                    val sig = ByteVector(Transaction.signInput(global.tx, inputIndex, input.witnessScript, input.sighashType ?: SigHash.SIGHASH_ALL, input.amount, SigVersion.SIGVERSION_WITNESS_V0, priv))
+                    Either.Right(Pair(input.copy(partialSigs = input.partialSigs + (priv.publicKey() to sig)), sig))
+                }
+            }
         }
     }
 
     /**
-     * Implements the PSBT finalizer role: finalizes a given non-witness input.
-     * This will clear all fields from the input except the utxo, scriptSig and unknown entries.
+     * Implements the PSBT finalizer role: finalizes a given segwit input.
+     * This will clear all fields from the input except the utxo, scriptSig, scriptWitness and unknown entries.
      *
-     * @param inputIndex index of the input that should be finalized.
-     * @param scriptSig signature script.
+     * @param outPoint input that should be finalized.
+     * @param scriptWitness witness script.
      * @return a psbt with the given input finalized.
      */
-    public fun finalize(inputIndex: Int, scriptSig: List<ScriptElt>): Either<UpdateFailure, Psbt> {
-        return when {
-            inputIndex >= inputs.size -> Either.Left(UpdateFailure.InvalidInput("input index must exist in the input tx"))
-            inputs[inputIndex].nonWitnessUtxo == null -> Either.Left(UpdateFailure.CannotFinalizeInput(inputIndex, "non-witness utxo is missing"))
-            else -> {
-                val finalizedInput = inputs[inputIndex].copy(
-                    sighashType = null,
-                    partialSigs = mapOf(),
-                    derivationPaths = mapOf(),
-                    redeemScript = null,
-                    witnessScript = null,
-                    ripemd160 = setOf(),
-                    sha256 = setOf(),
-                    hash160 = setOf(),
-                    hash256 = setOf(),
-                    scriptSig = scriptSig
-                )
-                Either.Right(this.copy(inputs = this.inputs.updated(inputIndex, finalizedInput)))
-            }
-        }
+    public fun finalizeWitnessInput(outPoint: OutPoint, scriptWitness: ScriptWitness): Either<UpdateFailure, Psbt> {
+        val inputIndex = global.tx.txIn.indexOfFirst { it.outPoint == outPoint }
+        if (inputIndex < 0) return Either.Left(UpdateFailure.InvalidInput("psbt transaction does not spend the provided outpoint"))
+        return finalizeWitnessInput(inputIndex, scriptWitness)
     }
 
     /**
-     * Implements the PSBT finalizer role: finalizes a given witness input.
+     * Implements the PSBT finalizer role: finalizes a given segwit input.
      * This will clear all fields from the input except the utxo, scriptSig, scriptWitness and unknown entries.
      *
      * @param inputIndex index of the input that should be finalized.
      * @param scriptWitness witness script.
      * @return a psbt with the given input finalized.
      */
-    public fun finalize(inputIndex: Int, scriptWitness: ScriptWitness): Either<UpdateFailure, Psbt> {
-        return when {
-            inputIndex >= inputs.size -> Either.Left(UpdateFailure.InvalidInput("input index must exist in the input tx"))
-            inputs[inputIndex].witnessUtxo == null -> Either.Left(UpdateFailure.CannotFinalizeInput(inputIndex, "witness utxo is missing"))
-            else -> {
-                val input = inputs[inputIndex]
-                val scriptSig = input.redeemScript?.let { listOf(OP_PUSHDATA(Script.write(it))) }
-                val finalizedInput = input.copy(
-                    sighashType = null,
-                    partialSigs = mapOf(),
-                    derivationPaths = mapOf(),
-                    redeemScript = null,
-                    witnessScript = null,
-                    ripemd160 = setOf(),
-                    sha256 = setOf(),
-                    hash160 = setOf(),
-                    hash256 = setOf(),
-                    scriptSig = scriptSig,
-                    scriptWitness = scriptWitness
-                )
+    public fun finalizeWitnessInput(inputIndex: Int, scriptWitness: ScriptWitness): Either<UpdateFailure, Psbt> {
+        if (inputIndex >= inputs.size) return Either.Left(UpdateFailure.InvalidInput("input index must exist in the input tx"))
+        return when (val input = inputs[inputIndex]) {
+            is Input.PartiallySignedInputWithoutUtxo -> Either.Left(UpdateFailure.CannotFinalizeInput(inputIndex, "cannot finalize: input is missing utxo details"))
+            is Input.NonWitnessInput.PartiallySignedNonWitnessInput -> Either.Left(UpdateFailure.CannotFinalizeInput(inputIndex, "cannot finalize: input is a non-segwit input"))
+            is Input.WitnessInput.PartiallySignedWitnessInput -> {
+                val scriptSig = input.redeemScript?.let { script -> listOf(OP_PUSHDATA(Script.write(script))) } // p2sh-embedded segwit
+                val finalizedInput = Input.WitnessInput.FinalizedWitnessInput(input.txOut, input.nonWitnessUtxo, scriptWitness, scriptSig, input.ripemd160, input.sha256, input.hash160, input.hash256, input.unknown)
                 Either.Right(this.copy(inputs = this.inputs.updated(inputIndex, finalizedInput)))
             }
+            else -> Either.Left(UpdateFailure.CannotFinalizeInput(inputIndex, ("cannot finalize: input has already been finalized")))
+        }
+    }
+
+    /**
+     * Implements the PSBT finalizer role: finalizes a given non-segwit input.
+     * This will clear all fields from the input except the utxo, scriptSig and unknown entries.
+     *
+     * @param outPoint input that should be finalized.
+     * @param scriptSig signature script.
+     * @return a psbt with the given input finalized.
+     */
+    public fun finalizeNonWitnessInput(outPoint: OutPoint, scriptSig: List<ScriptElt>): Either<UpdateFailure, Psbt> {
+        val inputIndex = global.tx.txIn.indexOfFirst { it.outPoint == outPoint }
+        if (inputIndex < 0) return Either.Left(UpdateFailure.InvalidInput("psbt transaction does not spend the provided outpoint"))
+        return finalizeNonWitnessInput(inputIndex, scriptSig)
+    }
+
+    /**
+     * Implements the PSBT finalizer role: finalizes a given non-segwit input.
+     * This will clear all fields from the input except the utxo, scriptSig and unknown entries.
+     *
+     * @param inputIndex index of the input that should be finalized.
+     * @param scriptSig signature script.
+     * @return a psbt with the given input finalized.
+     */
+    public fun finalizeNonWitnessInput(inputIndex: Int, scriptSig: List<ScriptElt>): Either<UpdateFailure, Psbt> {
+        if (inputIndex >= inputs.size) return Either.Left(UpdateFailure.InvalidInput("input index must exist in the input tx"))
+        return when (val input = inputs[inputIndex]) {
+            is Input.PartiallySignedInputWithoutUtxo -> Either.Left(UpdateFailure.CannotFinalizeInput(inputIndex, "cannot finalize: input is missing utxo details"))
+            is Input.WitnessInput.PartiallySignedWitnessInput -> Either.Left(UpdateFailure.CannotFinalizeInput(inputIndex, "cannot finalize: input is a segwit input"))
+            is Input.NonWitnessInput.PartiallySignedNonWitnessInput -> {
+                val finalizedInput = Input.NonWitnessInput.FinalizedNonWitnessInput(input.inputTx, input.outputIndex, scriptSig, input.ripemd160, input.sha256, input.hash160, input.hash256, input.unknown)
+                Either.Right(this.copy(inputs = this.inputs.updated(inputIndex, finalizedInput)))
+            }
+            else -> Either.Left(UpdateFailure.CannotFinalizeInput(inputIndex, ("cannot finalize: input has already been finalized")))
         }
     }
 
@@ -220,18 +471,17 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
      */
     public fun extract(): Either<UpdateFailure, Transaction> {
         val (finalTxsIn, utxos) = global.tx.txIn.zip(inputs).map { (txIn, input) ->
-            if (!isFinal(input)) {
-                return Either.Left(UpdateFailure.CannotExtractTx("some inputs are not finalized"))
-            }
             val finalTxIn = txIn.copy(
                 witness = input.scriptWitness ?: ScriptWitness.empty,
                 signatureScript = input.scriptSig?.let { ByteVector(Script.write(it)) } ?: ByteVector.empty
             )
-            val utxo = when {
-                input.nonWitnessUtxo != null && input.nonWitnessUtxo.txid != txIn.outPoint.txid -> return Either.Left(UpdateFailure.CannotExtractTx("non-witness utxo does not match unsigned tx input"))
-                input.nonWitnessUtxo != null && input.nonWitnessUtxo.txOut.size <= txIn.outPoint.index -> return Either.Left(UpdateFailure.CannotExtractTx("non-witness utxo index out of bounds"))
-                input.nonWitnessUtxo != null -> input.nonWitnessUtxo.txOut[txIn.outPoint.index.toInt()]
-                input.witnessUtxo != null -> input.witnessUtxo
+            val utxo = when (input) {
+                is Input.NonWitnessInput.FinalizedNonWitnessInput -> {
+                    if (input.inputTx.txid != txIn.outPoint.txid) return Either.Left(UpdateFailure.CannotExtractTx("non-witness utxo does not match unsigned tx input"))
+                    if (input.inputTx.txOut.size <= txIn.outPoint.index) return Either.Left(UpdateFailure.CannotExtractTx("non-witness utxo index out of bounds"))
+                    input.inputTx.txOut[txIn.outPoint.index.toInt()]
+                }
+                is Input.WitnessInput.FinalizedWitnessInput -> input.txOut
                 else -> return Either.Left(UpdateFailure.CannotExtractTx("some utxos are missing"))
             }
             Pair(finalTxIn, txIn.outPoint to utxo)
@@ -245,24 +495,15 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
         }
     }
 
-    private fun isFinal(input: PartiallySignedInput): Boolean {
-        // Everything except the utxo, the scriptSigs and unknown keys must be empty.
-        val emptied = input.redeemScript == null && input.witnessScript == null && input.partialSigs.isEmpty() && input.derivationPaths.isEmpty() && input.sighashType == null
-        // And we must have complete scriptSig for either a witness or non-witness utxo.
-        val hasWitnessData = input.witnessUtxo != null && input.scriptWitness != null
-        val hasNonWitnessData = input.nonWitnessUtxo != null && input.scriptSig != null
-        return emptied && (hasWitnessData || hasNonWitnessData)
-    }
-
     /**
      * Compute the fees paid by the PSBT.
      * Note that if some inputs have not been updated yet, the fee cannot be computed.
      */
     public fun computeFees(): Satoshi? {
-        val inputAmounts = inputs.zip(global.tx.txIn).map { (input, txIn) ->
-            when {
-                input.witnessUtxo != null -> input.witnessUtxo.amount
-                input.nonWitnessUtxo != null -> input.nonWitnessUtxo.txOut[txIn.outPoint.index.toInt()].amount
+        val inputAmounts = inputs.map { input ->
+            when (input) {
+                is Input.WitnessInput -> input.amount
+                is Input.NonWitnessInput -> input.amount
                 else -> null
             }
         }
@@ -274,6 +515,15 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
                 amountIn - amountOut
             }
         }
+    }
+
+    public fun getInput(outPoint: OutPoint): Input? {
+        val inputIndex = global.tx.txIn.indexOfFirst { it.outPoint == outPoint }
+        return if (inputIndex >= 0) inputs[inputIndex] else null
+    }
+
+    public fun getInput(inputIndex: Int): Input? {
+        return if (0 <= inputIndex && inputIndex < inputs.size) inputs[inputIndex] else null
     }
 
     public companion object {
@@ -306,61 +556,216 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
          */
         public data class Global(val version: Long, val tx: Transaction, val extendedPublicKeys: List<ExtendedPublicKeyWithMaster>, val unknown: List<DataEntry>)
 
-        /**
-         * A partially signed input. A valid PSBT must contain one such input per input of the [[Global.tx]].
-         *
-         * @param nonWitnessUtxo non-witness utxo, used when spending non-segwit outputs.
-         * @param witnessUtxo witness utxo, used when spending segwit outputs.
-         * @param sighashType sighash type to be used when producing signature for this output.
-         * @param partialSigs signatures as would be pushed to the stack from a scriptSig or witness.
-         * @param derivationPaths derivation paths used for the signatures.
-         * @param redeemScript redeemScript for this input if it has one.
-         * @param witnessScript witnessScript for this input if it has one.
-         * @param scriptSig fully constructed scriptSig with signatures and any other scripts necessary for the input to pass validation.
-         * @param scriptWitness fully constructed scriptWitness with signatures and any other scripts necessary for the input to pass validation.
-         * @param ripemd160 preimages for ripemd160 miniscript challenges.
-         * @param sha256 preimages for sha256 miniscript challenges.
-         * @param hash160 preimages for hash160 miniscript challenges.
-         * @param hash256 preimages for hash256 miniscript challenges.
-         * @param unknown (optional) unknown global entries.
-         */
-        public data class PartiallySignedInput(
-            val nonWitnessUtxo: Transaction?,
-            val witnessUtxo: TxOut?,
-            val sighashType: Int?,
-            val partialSigs: Map<PublicKey, ByteVector>,
-            val derivationPaths: Map<PublicKey, KeyPathWithMaster>,
-            val redeemScript: List<ScriptElt>?,
-            val witnessScript: List<ScriptElt>?,
-            val scriptSig: List<ScriptElt>?,
-            val scriptWitness: ScriptWitness?,
-            val ripemd160: Set<ByteVector>,
-            val sha256: Set<ByteVector>,
-            val hash160: Set<ByteVector>,
-            val hash256: Set<ByteVector>,
-            val unknown: List<DataEntry>
-        ) {
-            public companion object {
-                public val empty: PartiallySignedInput = PartiallySignedInput(null, null, null, mapOf(), mapOf(), null, null, null, null, setOf(), setOf(), setOf(), setOf(), listOf())
+        /** A PSBT input. A valid PSBT must contain one such input per input of the [[Global.tx]]. */
+        public sealed class Input {
+            // @formatter:off
+            /** Non-witness utxo, used when spending non-segwit outputs (may also be included when spending segwit outputs). */
+            public abstract val nonWitnessUtxo: Transaction?
+            /** Witness utxo, used when spending segwit outputs. */
+            public abstract val witnessUtxo: TxOut?
+            /** Sighash type to be used when producing signatures for this output. */
+            public abstract val sighashType: Int?
+            /** Signatures as would be pushed to the stack from a scriptSig or witness. */
+            public abstract val partialSigs: Map<PublicKey, ByteVector>
+            /** Derivation paths used for the signatures. */
+            public abstract val derivationPaths: Map<PublicKey, KeyPathWithMaster>
+            /** Redeem script for this input (when using p2sh). */
+            public abstract val redeemScript: List<ScriptElt>?
+            /** Witness script for this input (when using p2wsh). */
+            public abstract val witnessScript: List<ScriptElt>?
+            /** Fully constructed scriptSig with signatures and any other scripts necessary for the input to pass validation. */
+            public abstract val scriptSig: List<ScriptElt>?
+            /** Fully constructed scriptWitness with signatures and any other scripts necessary for the input to pass validation. */
+            public abstract val scriptWitness: ScriptWitness?
+            /** RipeMD160 preimages (e.g. for miniscript hash challenges). */
+            public abstract val ripemd160: Set<ByteVector>
+            /** Sha256 preimages (e.g. for miniscript hash challenges). */
+            public abstract val sha256: Set<ByteVector>
+            /** Hash160 preimages (e.g. for miniscript hash challenges). */
+            public abstract val hash160: Set<ByteVector>
+            /** Hash256 preimages (e.g. for miniscript hash challenges). */
+            public abstract val hash256: Set<ByteVector>
+            /** (optional) Unknown global entries. */
+            public abstract val unknown: List<DataEntry>
+            // @formatter:on
+
+            /**
+             * A partially signed input without details about the utxo.
+             * More signatures may need to be added before it can be finalized.
+             */
+            public data class PartiallySignedInputWithoutUtxo(
+                override val sighashType: Int?,
+                override val derivationPaths: Map<PublicKey, KeyPathWithMaster>,
+                override val ripemd160: Set<ByteVector>,
+                override val sha256: Set<ByteVector>,
+                override val hash160: Set<ByteVector>,
+                override val hash256: Set<ByteVector>,
+                override val unknown: List<DataEntry>
+            ) : Input() {
+                override val nonWitnessUtxo: Transaction? = null
+                override val witnessUtxo: TxOut? = null
+                override val redeemScript: List<ScriptElt>? = null
+                override val witnessScript: List<ScriptElt>? = null
+                override val partialSigs: Map<PublicKey, ByteVector> = mapOf()
+                override val scriptSig: List<ScriptElt>? = null
+                override val scriptWitness: ScriptWitness? = null
+            }
+
+            /**
+             * A fully signed input without details about the utxo.
+             * Input finalizers should keep the utxo to allow transaction extractors to verify the final network serialized
+             * transaction, but it's not mandatory, so we may not have it available when parsing psbt inputs.
+             */
+            public data class FinalizedInputWithoutUtxo(
+                override val scriptWitness: ScriptWitness?,
+                override val scriptSig: List<ScriptElt>?,
+                override val ripemd160: Set<ByteVector>,
+                override val sha256: Set<ByteVector>,
+                override val hash160: Set<ByteVector>,
+                override val hash256: Set<ByteVector>,
+                override val unknown: List<DataEntry>
+            ) : Input() {
+                override val nonWitnessUtxo: Transaction? = null
+                override val witnessUtxo: TxOut? = null
+                override val sighashType: Int? = null
+                override val partialSigs: Map<PublicKey, ByteVector> = mapOf()
+                override val derivationPaths: Map<PublicKey, KeyPathWithMaster> = mapOf()
+                override val redeemScript: List<ScriptElt>? = null
+                override val witnessScript: List<ScriptElt>? = null
+            }
+
+            /** An input spending a segwit output. */
+            public sealed class WitnessInput : Input() {
+                public abstract val txOut: TxOut
+                public val amount: Satoshi by lazy { txOut.amount }
+                override val witnessUtxo: TxOut? by lazy { txOut }
+
+                /** A partially signed segwit input. More signatures may need to be added before it can be finalized. */
+                public data class PartiallySignedWitnessInput(
+                    override val txOut: TxOut,
+                    override val nonWitnessUtxo: Transaction?,
+                    override val sighashType: Int?,
+                    override val partialSigs: Map<PublicKey, ByteVector>,
+                    override val derivationPaths: Map<PublicKey, KeyPathWithMaster>,
+                    override val redeemScript: List<ScriptElt>?,
+                    override val witnessScript: List<ScriptElt>?,
+                    override val ripemd160: Set<ByteVector>,
+                    override val sha256: Set<ByteVector>,
+                    override val hash160: Set<ByteVector>,
+                    override val hash256: Set<ByteVector>,
+                    override val unknown: List<DataEntry>
+                ) : WitnessInput() {
+                    override val scriptSig: List<ScriptElt>? = null
+                    override val scriptWitness: ScriptWitness? = null
+                }
+
+                /** A fully signed segwit input. */
+                public data class FinalizedWitnessInput(
+                    override val txOut: TxOut,
+                    override val nonWitnessUtxo: Transaction?,
+                    override val scriptWitness: ScriptWitness,
+                    override val scriptSig: List<ScriptElt>?,
+                    override val ripemd160: Set<ByteVector>,
+                    override val sha256: Set<ByteVector>,
+                    override val hash160: Set<ByteVector>,
+                    override val hash256: Set<ByteVector>,
+                    override val unknown: List<DataEntry>
+                ) : WitnessInput() {
+                    override val sighashType: Int? = null
+                    override val partialSigs: Map<PublicKey, ByteVector> = mapOf()
+                    override val derivationPaths: Map<PublicKey, KeyPathWithMaster> = mapOf()
+                    override val redeemScript: List<ScriptElt>? = null
+                    override val witnessScript: List<ScriptElt>? = null
+                }
+            }
+
+            /** An input spending a non-segwit output. */
+            public sealed class NonWitnessInput : Input() {
+                public abstract val inputTx: Transaction
+                public abstract val outputIndex: Int
+                public val amount: Satoshi by lazy { inputTx.txOut[outputIndex].amount }
+                override val nonWitnessUtxo: Transaction? by lazy { inputTx }
+
+                // The following fields should only be present for inputs which spend segwit outputs (including P2SH embedded ones).
+                override val witnessUtxo: TxOut? = null
+                override val witnessScript: List<ScriptElt>? = null
+
+                /** A partially signed non-segwit input. More signatures may need to be added before it can be finalized. */
+                public data class PartiallySignedNonWitnessInput(
+                    override val inputTx: Transaction,
+                    override val outputIndex: Int,
+                    override val sighashType: Int?,
+                    override val partialSigs: Map<PublicKey, ByteVector>,
+                    override val derivationPaths: Map<PublicKey, KeyPathWithMaster>,
+                    override val redeemScript: List<ScriptElt>?,
+                    override val ripemd160: Set<ByteVector>,
+                    override val sha256: Set<ByteVector>,
+                    override val hash160: Set<ByteVector>,
+                    override val hash256: Set<ByteVector>,
+                    override val unknown: List<DataEntry>
+                ) : NonWitnessInput() {
+                    override val scriptSig: List<ScriptElt>? = null
+                    override val scriptWitness: ScriptWitness? = null
+                }
+
+                /** A fully signed non-segwit input. */
+                public data class FinalizedNonWitnessInput(
+                    override val inputTx: Transaction,
+                    override val outputIndex: Int,
+                    override val scriptSig: List<ScriptElt>,
+                    override val ripemd160: Set<ByteVector>,
+                    override val sha256: Set<ByteVector>,
+                    override val hash160: Set<ByteVector>,
+                    override val hash256: Set<ByteVector>,
+                    override val unknown: List<DataEntry>
+                ) : NonWitnessInput() {
+                    override val sighashType: Int? = null
+                    override val partialSigs: Map<PublicKey, ByteVector> = mapOf()
+                    override val derivationPaths: Map<PublicKey, KeyPathWithMaster> = mapOf()
+                    override val redeemScript: List<ScriptElt>? = null
+                    override val witnessScript: List<ScriptElt>? = null
+                    override val scriptWitness: ScriptWitness? = null
+                }
             }
         }
 
-        /**
-         * A partially signed output. A valid PSBT must contain one such output per output of the [[Global.tx]].
-         *
-         * @param redeemScript redeemScript for this output if it has one.
-         * @param witnessScript witnessScript for this output if it has one.
-         * @param derivationPaths derivation paths used to produce the public keys associated to this output.
-         * @param unknown (optional) unknown global entries.
-         */
-        public data class PartiallySignedOutput(
-            val redeemScript: List<ScriptElt>?,
-            val witnessScript: List<ScriptElt>?,
-            val derivationPaths: Map<PublicKey, KeyPathWithMaster>,
-            val unknown: List<DataEntry>
-        ) {
-            public companion object {
-                public val empty: PartiallySignedOutput = PartiallySignedOutput(null, null, mapOf(), listOf())
+        /** A PSBT output. A valid PSBT must contain one such output per output of the [[Global.tx]]. */
+        public sealed class Output {
+            // @formatter:off
+            /** Redeem script for this output (when using p2sh). */
+            public abstract val redeemScript: List<ScriptElt>?
+            /** Witness script for this output (when using p2wsh). */
+            public abstract val witnessScript: List<ScriptElt>?
+            /** Derivation paths used to produce the public keys associated to this output. */
+            public abstract val derivationPaths: Map<PublicKey, KeyPathWithMaster>
+            /** (optional) Unknown global entries. */
+            public abstract val unknown: List<DataEntry>
+            // @formatter:on
+
+            /** A non-segwit output. */
+            public data class NonWitnessOutput(
+                override val redeemScript: List<ScriptElt>?,
+                override val derivationPaths: Map<PublicKey, KeyPathWithMaster>,
+                override val unknown: List<DataEntry>
+            ) : Output() {
+                override val witnessScript: List<ScriptElt>? = null
+            }
+
+            /** A segwit output. */
+            public data class WitnessOutput(
+                override val witnessScript: List<ScriptElt>?,
+                override val redeemScript: List<ScriptElt>?,
+                override val derivationPaths: Map<PublicKey, KeyPathWithMaster>,
+                override val unknown: List<DataEntry>
+            ) : Output()
+
+            /** An output for which usage of segwit is currently unknown. */
+            public data class UnspecifiedOutput(
+                override val derivationPaths: Map<PublicKey, KeyPathWithMaster>,
+                override val unknown: List<DataEntry>
+            ) : Output() {
+                override val redeemScript: List<ScriptElt>? = null
+                override val witnessScript: List<ScriptElt>? = null
             }
         }
 
@@ -370,9 +775,14 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
             public data class InvalidWitnessUtxo(val reason: String) : UpdateFailure()
             public data class CannotCombine(val reason: String) : UpdateFailure()
             public data class CannotJoin(val reason: String) : UpdateFailure()
+            public data class CannotUpdateInput(val index: Int, val reason: String) : UpdateFailure()
+            public data class CannotUpdateOutput(val index: Int, val reason: String) : UpdateFailure()
+            public data class CannotSignInput(val index: Int, val reason: String) : UpdateFailure()
             public data class CannotFinalizeInput(val index: Int, val reason: String) : UpdateFailure()
             public data class CannotExtractTx(val reason: String) : UpdateFailure()
         }
+
+        public data class SignPsbtResult(val psbt: Psbt, val sig: ByteVector)
 
         /**
          * Implements the PSBT combiner role: combines multiple psbts for the same unsigned transaction.
@@ -392,7 +802,7 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
                     )
                     val combined = Psbt(
                         global,
-                        global.tx.txIn.indices.map { i -> combineInput(psbts.map { it.inputs[i] }) },
+                        global.tx.txIn.indices.map { i -> combineInput(global.tx.txIn[i], psbts.map { it.inputs[i] }) },
                         global.tx.txOut.indices.map { i -> combineOutput(psbts.map { it.outputs[i] }) }
                     )
                     Either.Right(combined)
@@ -404,7 +814,8 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
 
         private fun combineExtendedPublicKeys(keys: List<List<ExtendedPublicKeyWithMaster>>): List<ExtendedPublicKeyWithMaster> = keys.flatten().associateBy { it.extendedPublicKey }.values.toList()
 
-        private fun combineInput(inputs: List<PartiallySignedInput>): PartiallySignedInput = PartiallySignedInput(
+        private fun combineInput(txIn: TxIn, inputs: List<Input>): Input = createInput(
+            txIn,
             inputs.mapNotNull { it.nonWitnessUtxo }.firstOrNull(),
             inputs.mapNotNull { it.witnessUtxo }.firstOrNull(),
             inputs.mapNotNull { it.sighashType }.firstOrNull(),
@@ -421,7 +832,7 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
             combineUnknown(inputs.map { it.unknown })
         )
 
-        private fun combineOutput(outputs: List<PartiallySignedOutput>): PartiallySignedOutput = PartiallySignedOutput(
+        private fun combineOutput(outputs: List<Output>): Output = createOutput(
             outputs.mapNotNull { it.redeemScript }.firstOrNull(),
             outputs.mapNotNull { it.witnessScript }.firstOrNull(),
             outputs.flatMap { it.derivationPaths.toList() }.toMap(),
@@ -467,7 +878,7 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
             return ByteVector(output.toByteArray())
         }
 
-        public fun write(psbt: Psbt, out: Output) {
+        public fun write(psbt: Psbt, out: fr.acinq.bitcoin.io.Output) {
             /********** Magic header **********/
             out.write(0x70)
             out.write(0x73)
@@ -535,7 +946,7 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
             return publicKeys.toList().sortedWith { a, b -> LexicographicalOrdering.compare(a.first, b.first) }
         }
 
-        private fun writeDataEntry(entry: DataEntry, output: Output) {
+        private fun writeDataEntry(entry: DataEntry, output: fr.acinq.bitcoin.io.Output) {
             BtcSerializer.writeVarint(entry.key.size(), output)
             output.write(entry.key.bytes)
             BtcSerializer.writeVarint(entry.value.size(), output)
@@ -558,7 +969,7 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
 
         public fun read(input: ByteVector): Either<ParseFailure, Psbt> = read(ByteArrayInput(input.toByteArray()))
         public fun read(input: ByteArray): Either<ParseFailure, Psbt> = read(ByteArrayInput(input))
-        public fun read(input: Input): Either<ParseFailure, Psbt> {
+        public fun read(input: fr.acinq.bitcoin.io.Input): Either<ParseFailure, Psbt> {
             /********** Magic header **********/
             if (input.read() != 0x70 || input.read() != 0x73 || input.read() != 0x62 || input.read() != 0x74) {
                 return Either.Left(ParseFailure.InvalidMagicBytes)
@@ -754,7 +1165,8 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
                         else -> it.value
                     }
                 }.toSet()
-                PartiallySignedInput(
+                createInput(
+                    txIn,
                     nonWitnessUtxo,
                     witnessUtxo,
                     sighashType,
@@ -807,7 +1219,7 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
                         }
                     }
                 }.toMap()
-                PartiallySignedOutput(redeemScript, witnessScript, derivationPaths, unknown)
+                createOutput(redeemScript, witnessScript, derivationPaths, unknown)
             }
 
             return if (input.availableBytes != 0) {
@@ -817,13 +1229,55 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
             }
         }
 
+        private fun createInput(
+            txIn: TxIn,
+            nonWitnessUtxo: Transaction?,
+            witnessUtxo: TxOut?,
+            sighashType: Int?,
+            partialSigs: Map<PublicKey, ByteVector>,
+            derivationPaths: Map<PublicKey, KeyPathWithMaster>,
+            redeemScript: List<ScriptElt>?,
+            witnessScript: List<ScriptElt>?,
+            scriptSig: List<ScriptElt>?,
+            scriptWitness: ScriptWitness?,
+            ripemd160: Set<ByteVector>,
+            sha256: Set<ByteVector>,
+            hash160: Set<ByteVector>,
+            hash256: Set<ByteVector>,
+            unknown: List<DataEntry>
+        ): Input {
+            val emptied = redeemScript == null && witnessScript == null && partialSigs.isEmpty() && derivationPaths.isEmpty() && sighashType == null
+            return when {
+                // @formatter:off
+                // If the input is finalized, it must have been emptied otherwise it's invalid.
+                witnessUtxo != null && scriptWitness != null && emptied -> Input.WitnessInput.FinalizedWitnessInput(witnessUtxo, nonWitnessUtxo, scriptWitness, scriptSig, ripemd160, sha256, hash160, hash256, unknown)
+                nonWitnessUtxo != null && scriptSig != null && emptied -> Input.NonWitnessInput.FinalizedNonWitnessInput(nonWitnessUtxo, txIn.outPoint.index.toInt(), scriptSig, ripemd160, sha256, hash160, hash256, unknown)
+                (scriptSig != null || scriptWitness != null) && emptied -> Input.FinalizedInputWithoutUtxo(scriptWitness, scriptSig, ripemd160, sha256, hash160, hash256, unknown)
+                witnessUtxo != null -> Input.WitnessInput.PartiallySignedWitnessInput(witnessUtxo, nonWitnessUtxo, sighashType, partialSigs, derivationPaths, redeemScript, witnessScript, ripemd160, sha256, hash160, hash256, unknown)
+                nonWitnessUtxo != null -> Input.NonWitnessInput.PartiallySignedNonWitnessInput(nonWitnessUtxo, txIn.outPoint.index.toInt(), sighashType, partialSigs, derivationPaths, redeemScript, ripemd160, sha256, hash160, hash256, unknown)
+                else -> Input.PartiallySignedInputWithoutUtxo(sighashType, derivationPaths, ripemd160, sha256, hash160, hash256, unknown)
+                // @formatter:on
+            }
+        }
+
+        private fun createOutput(
+            redeemScript: List<ScriptElt>?,
+            witnessScript: List<ScriptElt>?,
+            derivationPaths: Map<PublicKey, KeyPathWithMaster>,
+            unknown: List<DataEntry>
+        ): Output = when {
+            witnessScript != null -> Output.WitnessOutput(witnessScript, redeemScript, derivationPaths, unknown)
+            redeemScript != null -> Output.NonWitnessOutput(redeemScript, derivationPaths, unknown)
+            else -> Output.UnspecifiedOutput(derivationPaths, unknown)
+        }
+
         private sealed class ReadEntryFailure {
             object DuplicateKeys : ReadEntryFailure()
             object InvalidData : ReadEntryFailure()
             object EndOfDataMap : ReadEntryFailure()
         }
 
-        private fun readDataMap(input: Input, entries: List<DataEntry> = listOf()): Either<ReadEntryFailure, List<DataEntry>> {
+        private fun readDataMap(input: fr.acinq.bitcoin.io.Input, entries: List<DataEntry> = listOf()): Either<ReadEntryFailure, List<DataEntry>> {
             return when (val result = readDataEntry(input)) {
                 is Either.Right -> readDataMap(input, entries + result.value)
                 is Either.Left -> when (result.value) {
@@ -840,7 +1294,7 @@ public data class Psbt(val global: Global, val inputs: List<PartiallySignedInput
             }
         }
 
-        private fun readDataEntry(input: Input): Either<ReadEntryFailure, DataEntry> {
+        private fun readDataEntry(input: fr.acinq.bitcoin.io.Input): Either<ReadEntryFailure, DataEntry> {
             if (input.availableBytes == 0) return Either.Left(ReadEntryFailure.InvalidData)
             val keyLength = BtcSerializer.varint(input).toInt()
             if (keyLength == 0) return Either.Left(ReadEntryFailure.EndOfDataMap)


### PR DESCRIPTION
Add more structure to PSBT inputs and outputs.
The main change is to split segwit and non-segwit inputs, as they have different requirements.

A higher-level application will always know whether the inputs it's responsible for use segwit or not, so they'll be able to take advantage of these new types (instead of manually parsing the PSBT fields themselves).