### PR TITLE
Add test for large opSuccess tx

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
@@ -371,22 +371,34 @@ class TaprootTestsCommon {
     }
 
     @Test
-    fun `parse and validate huge transaction made of empty pushes`() {
-        // this is the tx that broke btcd/lnd: https://github.com/btcsuite/btcd/issues/1906
+    fun `parse and validate huge transaction enabled by OP_SUCCESSx`() {
         // construct large taproot tx: 73be398c4bdc43709db7398106609eea2a7841aaf3a4fa2000dc18184faa2a7e
-        val pre = Hex.decode("020000000001015d631bf6a5dbb22cdfad0349e54367393e76bfdec3f187207adcfbbc04d92bfe0000000000ffffffff010000000000000000266a24796f75276c6c2072756e20636c6e2e20616e6420796f75276c6c2062652068617070792efe23a107")
-        val post = Hex.decode("015021c11dae61a4a8f841952be3a511502d4f56e889ffa0685aa0098773ea2d4309f62400000000")
-        val buffer = pre + ByteArray(500002) { 0 } + post
-        val tx = Transaction.read(buffer)
-        assertEquals(500003, tx.txIn[0].witness.stack.size)
+        // this is the tx that broke btcd/lnd: https://github.com/btcsuite/btcd/issues/1906
         val parentTx = Transaction.read("0200000000010219d3bdb21c713911fe18cf2dbe8dde9e85c2bdde76139a30c725a7f0115a983b0100000000fdffffffb9da566f902363594ce178f8b32e92a45fec5860e1121aae58b15178fbd3fb670000000000fdffffff019f313800000000002251209bb9efbddf9d70afd3ac2cef011747236bdf90832a78b08f57d1139f07aa9185024730440220146d18445bd3fb00f5140e4ef886cff7b432c55911730483a202abfe8ca43880022074e143eec20286df9ab06194a638dbbdaa7ef3001c252f9b83c8270a608ce04a01210349e84631e7d206600f72fc30d43fa9004171c5d314ea9f88e92687394b2560f3024730440220140c1888004c649a7ca4135bc9e4fe10fd4bf30264126a248ad9c5c762a387e702204de3da8bf5304abe05fba690a91eed2cab59444592be520640280ee7f1b5467401210290d5dab3b51ae9293d07ace66bdfa6bbaa5f398d1a5464b2ede4d41104aae97e00000000")
-        assertFails {
-            Transaction.correctlySpends(tx, parentTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-        }
-        Transaction.correctlySpends(tx, parentTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS xor ScriptFlags.SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS)
+        val count = 500001
+        val tx = Transaction(
+            version = 2L,
+            txIn = listOf(TxIn(OutPoint(parentTx, 0), sequence = 0xffffffff)),
+            txOut = listOf(TxOut(amount = 0L.toSatoshi(), publicKeyScript = Hex.decode("6a24796f75276c6c2072756e20636c6e2e20616e6420796f75276c6c2062652068617070792e"))),
+            lockTime = 0L
+        )
+        val sig = ByteVector("c11dae61a4a8f841952be3a511502d4f56e889ffa0685aa0098773ea2d4309f624")
+        val opSuccess = ByteVector("0x50") // OP_RESERVED
+        val stack = Array(count) { ByteVector("") }.toList()
+        val witness = ScriptWitness(stack + opSuccess + sig) // must not exceed available Java heap space
+        val tx2 = tx.updateWitness(0, witness) //, op, sig)
+        assertEquals(count+2, tx2.txIn[0].witness.stack.size)
+        assertEquals(ByteVector32("73be398c4bdc43709db7398106609eea2a7841aaf3a4fa2000dc18184faa2a7e"), tx.txid)
 
-        // check that we can also serialize this tx and get the same result
-        val serializedTx = Transaction.write(tx)
-        assertContentEquals(buffer, serializedTx)
+        assertFails {
+            // invalid and not relayed by nodes with default policy settings because of OP_SUCCESSx in the script
+            Transaction.correctlySpends(tx2, parentTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+        }
+        // block validation deactivates the policy which rejects this transactions
+        Transaction.correctlySpends(tx2, parentTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS xor ScriptFlags.SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS)
+
+        // check that we can also deserialize this tx and get the same result
+        val tx3 = Transaction.read(Transaction.write(tx2))
+        assertContentEquals(Transaction.write(tx2), Transaction.write(tx3))
     }
 }


### PR DESCRIPTION
This PR creates a test for the huge `OP_SUCCESSx` tx created by [@brqgoo](https://twitter.com/brqgoo/status/1587397646125260802) in tx [73be398c4bdc43709db7398106609eea2a7841aaf3a4fa2000dc18184faa2a7e](https://blockstream.info/tx/73be398c4bdc43709db7398106609eea2a7841aaf3a4fa2000dc18184faa2a7e) and discussed in btcd issue [#1906]( https://github.com/btcsuite/btcd/issues/1906)

This transaction shouldn't be relayed, but once mined will be considered valid by bitcoin-kmp.