### PR TITLE
Simple changes to make this library more scala-friendly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 group = "fr.acinq.bitcoin"
-version = "0.10.0"
+version = "0.11.0-SNAPSHOT"
 
 repositories {
     google()
@@ -37,7 +37,7 @@ kotlin {
     }
 
     sourceSets {
-        val secp256k1KmpVersion = "0.7.0"
+        val secp256k1KmpVersion = "0.7.1"
 
         val commonMain by getting {
             dependencies {

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Crypto.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Crypto.kt
@@ -162,8 +162,9 @@ public object Crypto {
          * private key is used as-is
          */
         public object NoTweak : SchnorrTweak()
+    }
 
-        public sealed class TaprootTweak: SchnorrTweak()
+    public sealed class TaprootTweak: SchnorrTweak() {
         /**
          * private key is tweaked with H_TapTweak(public key) (this is used for key path spending when no scripts are present)
          */
@@ -174,7 +175,6 @@ public object Crypto {
          */
         public data class ScriptTweak(val merkleRoot: ByteVector32) : TaprootTweak()
     }
-
     /**
      * @param data data to sign (32 bytes)
      * @param privateKey private key
@@ -186,8 +186,8 @@ public object Crypto {
     public fun signSchnorr(data: ByteVector32, privateKey: PrivateKey, schnorrTweak: SchnorrTweak, auxrand32: ByteVector32? = null): ByteVector64 {
         val priv = when(schnorrTweak)  {
             SchnorrTweak.NoTweak -> privateKey
-            is SchnorrTweak.NoScriptTweak -> privateKey.tweak(privateKey.xOnlyPublicKey().tweak(schnorrTweak))
-            is SchnorrTweak.ScriptTweak -> privateKey.tweak(privateKey.xOnlyPublicKey().tweak(schnorrTweak))
+            is TaprootTweak.NoScriptTweak -> privateKey.tweak(privateKey.xOnlyPublicKey().tweak(schnorrTweak))
+            is TaprootTweak.ScriptTweak -> privateKey.tweak(privateKey.xOnlyPublicKey().tweak(schnorrTweak))
         }
         val sig = Secp256k1.signSchnorr(data.toByteArray(), priv.value.toByteArray(), auxrand32?.toByteArray()).byteVector64()
         require(verifySignatureSchnorr(data, sig, priv.xOnlyPublicKey())) { "Cannot create Schnorr signature" }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Script.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Script.kt
@@ -1341,7 +1341,7 @@ public object Script {
                             Crypto.taggedHash(if (LexicographicalOrdering.isLessThan(a, b)) a.toByteArray() + b.toByteArray() else b.toByteArray() + a.toByteArray(), "TapBranch")
                         }
                         val parity = (control[0].toInt() and 0x01) == 0x01
-                        require(Pair(outputKey, parity) == internalKey.outputKey(Crypto.SchnorrTweak.ScriptTweak(merkleRoot)))
+                        require(Pair(outputKey, parity) == internalKey.outputKey(Crypto.TaprootTweak.ScriptTweak(merkleRoot)))
 
                         if (leafVersion == TAPROOT_LEAF_TAPSCRIPT) {
                             this.context.executionData = this.context.executionData.copy(validationWeightLeft = ScriptWitness.write(witness).size + VALIDATION_WEIGHT_OFFSET)

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/ScriptTree.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/ScriptTree.kt
@@ -16,6 +16,7 @@
 package fr.acinq.bitcoin
 
 import fr.acinq.bitcoin.io.ByteArrayOutput
+import kotlin.jvm.JvmStatic
 
 /**
  * leaf of a script tree used to create and spend tapscript transactions
@@ -46,6 +47,7 @@ public sealed class ScriptTree<T> {
         /**
          * @return the hash of the input merkle tree
          */
+        @JvmStatic
         public fun hash(tree: ScriptTree<ScriptLeaf>): ByteVector32 = when (tree) {
             is Leaf -> tree.value.hash
             is Branch -> {

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/XonlyPublicKey.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/XonlyPublicKey.kt
@@ -26,10 +26,10 @@ public data class XonlyPublicKey(@JvmField val value: ByteVector32) {
 
     val publicKey: PublicKey = PublicKey(byteArrayOf(2) + value.toByteArray())
 
-    public fun tweak(tapTweak: Crypto.SchnorrTweak.TaprootTweak):  ByteVector32 {
-        return when(tapTweak) {
-            Crypto.SchnorrTweak.NoScriptTweak -> Crypto.taggedHash(value.toByteArray(), "TapTweak")
-            is Crypto.SchnorrTweak.ScriptTweak -> Crypto.taggedHash(value.toByteArray() + tapTweak.merkleRoot.toByteArray(), "TapTweak")
+    public fun tweak(tapTweak: Crypto.TaprootTweak): ByteVector32 {
+        return when (tapTweak) {
+            Crypto.TaprootTweak.NoScriptTweak -> Crypto.taggedHash(value.toByteArray(), "TapTweak")
+            is Crypto.TaprootTweak.ScriptTweak -> Crypto.taggedHash(value.toByteArray() + tapTweak.merkleRoot.toByteArray(), "TapTweak")
         }
     }
 
@@ -38,7 +38,7 @@ public data class XonlyPublicKey(@JvmField val value: ByteVector32) {
      * @param tapTweak taproot tweak
      * @return an (x-only pubkey, parity) pair
      */
-    public fun outputKey(tapTweak: Crypto.SchnorrTweak.TaprootTweak): Pair<XonlyPublicKey, Boolean> = this + PrivateKey(tweak(tapTweak)).publicKey()
+    public fun outputKey(tapTweak: Crypto.TaprootTweak): Pair<XonlyPublicKey, Boolean> = this + PrivateKey(tweak(tapTweak)).publicKey()
 
     /**
      * add a public key to this x-only key

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/BIP86TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/BIP86TestsCommon.kt
@@ -19,7 +19,7 @@ class BIP86TestsCommon {
         assertEquals(key.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/0/0")).secretkeybytes)
         val internalKey = XonlyPublicKey(key.publicKey)
         assertEquals(internalKey.value, ByteVector32("cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115"))
-        val outputKey = internalKey.outputKey(Crypto.SchnorrTweak.NoScriptTweak).first
+        val outputKey = internalKey.outputKey(Crypto.TaprootTweak.NoScriptTweak).first
         assertEquals(outputKey.value, ByteVector32("a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"))
         val script = listOf(OP_1, OP_PUSHDATA(outputKey.value))
         assertEquals(Script.write(script).byteVector(), ByteVector("5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"))
@@ -29,7 +29,7 @@ class BIP86TestsCommon {
         assertEquals(key1.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/0/1")).secretkeybytes)
         val internalKey1 = XonlyPublicKey(key1.publicKey)
         assertEquals(internalKey1.value, ByteVector32("83dfe85a3151d2517290da461fe2815591ef69f2b18a2ce63f01697a8b313145"))
-        val outputKey1 = internalKey1.outputKey(Crypto.SchnorrTweak.NoScriptTweak).first
+        val outputKey1 = internalKey1.outputKey(Crypto.TaprootTweak.NoScriptTweak).first
         assertEquals(outputKey1.value, ByteVector32("a82f29944d65b86ae6b5e5cc75e294ead6c59391a1edc5e016e3498c67fc7bbb"))
         val script1 = listOf(OP_1, OP_PUSHDATA(outputKey1.value))
         assertEquals(Script.write(script1).byteVector(), ByteVector("5120a82f29944d65b86ae6b5e5cc75e294ead6c59391a1edc5e016e3498c67fc7bbb"))
@@ -39,7 +39,7 @@ class BIP86TestsCommon {
         assertEquals(key2.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/1/0")).secretkeybytes)
         val internalKey2 = XonlyPublicKey(key2.publicKey)
         assertEquals(internalKey2.value, ByteVector32("399f1b2f4393f29a18c937859c5dd8a77350103157eb880f02e8c08214277cef"))
-        val outputKey2 = internalKey2.outputKey(Crypto.SchnorrTweak.NoScriptTweak).first
+        val outputKey2 = internalKey2.outputKey(Crypto.TaprootTweak.NoScriptTweak).first
         assertEquals(outputKey2.value, ByteVector32("882d74e5d0572d5a816cef0041a96b6c1de832f6f9676d9605c44d5e9a97d3dc"))
         val script2 = listOf(OP_1, OP_PUSHDATA(outputKey2.value))
         assertEquals(Script.write(script2).byteVector(), ByteVector("5120882d74e5d0572d5a816cef0041a96b6c1de832f6f9676d9605c44d5e9a97d3dc"))
@@ -51,7 +51,7 @@ class BIP86TestsCommon {
         val (_, master) = DeterministicWallet.ExtendedPrivateKey.decode("tprv8ZgxMBicQKsPeQQADibg4WF7mEasy3piWZUHyThAzJCPNgMHDVYhTCVfev3jFbDhcYm4GimeFMbbi9z1d9rfY1aL5wfJ9mNebQ4thJ62EJb")
         val key = DeterministicWallet.derivePrivateKey(master, "86'/1'/0'/0/1")
         val internalKey = XonlyPublicKey(key.publicKey)
-        val outputKey = internalKey.outputKey(Crypto.SchnorrTweak.NoScriptTweak).first
+        val outputKey = internalKey.outputKey(Crypto.TaprootTweak.NoScriptTweak).first
         assertEquals("tb1phlhs7afhqzkgv0n537xs939s687826vn8l24ldkrckvwsnlj3d7qj6u57c", Bech32.encodeWitnessAddress("tb", 1, outputKey.value.toByteArray()))
     }
 
@@ -75,7 +75,7 @@ class BIP86TestsCommon {
         for (i in 0 until  10) {
             val key = DeterministicWallet.derivePrivateKey(master, "86'/1'/0'/0/$i")
             val internalKey = XonlyPublicKey(key.publicKey)
-            val outputKey = internalKey.outputKey(Crypto.SchnorrTweak.NoScriptTweak).first
+            val outputKey = internalKey.outputKey(Crypto.TaprootTweak.NoScriptTweak).first
             assertEquals(expected[i], Bech32.encodeWitnessAddress("tb", 1, outputKey.value.toByteArray()))
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/reference/BIP341TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/reference/BIP341TestsCommon.kt
@@ -56,7 +56,7 @@ class BIP341TestsCommon {
                 val internalPubkey = XonlyPublicKey(internalPrivkey.publicKey())
                 val intermediary = it.jsonObject["intermediary"]!!.jsonObject
                 assertEquals(ByteVector32(intermediary["internalPubkey"]!!.jsonPrimitive.content), internalPubkey.value)
-                val tweak = internalPubkey.tweak(if (merkleRoot == null) Crypto.SchnorrTweak.NoScriptTweak else Crypto.SchnorrTweak.ScriptTweak(merkleRoot))
+                val tweak = internalPubkey.tweak(if (merkleRoot == null) Crypto.TaprootTweak.NoScriptTweak else Crypto.TaprootTweak.ScriptTweak(merkleRoot))
                 assertEquals(ByteVector32(intermediary["tweak"]!!.jsonPrimitive.content), tweak)
 
                 val tweakedPrivateKey = internalPrivkey.tweak(tweak)
@@ -65,7 +65,7 @@ class BIP341TestsCommon {
                 val hash = Transaction.hashForSigningSchnorr(rawUnsignedTx, txinIndex, utxosSpent, hashType, 0)
                 assertEquals(ByteVector32(intermediary["sigHash"]!!.jsonPrimitive.content), hash)
 
-                val sig = Crypto.signSchnorr(hash, internalPrivkey, if (merkleRoot == null) Crypto.SchnorrTweak.NoScriptTweak else Crypto.SchnorrTweak.ScriptTweak(merkleRoot))
+                val sig = Crypto.signSchnorr(hash, internalPrivkey, if (merkleRoot == null) Crypto.TaprootTweak.NoScriptTweak else Crypto.TaprootTweak.ScriptTweak(merkleRoot))
                 val witness = when (hashType) {
                     SigHash.SIGHASH_DEFAULT -> sig
                     else -> (sig + byteArrayOf(hashType.toByte()))
@@ -91,7 +91,7 @@ class BIP341TestsCommon {
 
             val intermediary = it.jsonObject["intermediary"]!!.jsonObject
             val merkleRoot = scriptTree?.let { ScriptTree.hash(it) }
-            val (tweakedKey, parity) = internalPubkey.outputKey(if (merkleRoot == null) Crypto.SchnorrTweak.NoScriptTweak else Crypto.SchnorrTweak.ScriptTweak(merkleRoot))
+            val (tweakedKey, parity) = internalPubkey.outputKey(if (merkleRoot == null) Crypto.TaprootTweak.NoScriptTweak else Crypto.TaprootTweak.ScriptTweak(merkleRoot))
             merkleRoot?.let { assertEquals(ByteVector32(intermediary["merkleRoot"]!!.jsonPrimitive.content), it) }
             assertEquals(ByteVector32(intermediary["tweakedPubkey"]!!.jsonPrimitive.content), tweakedKey.value)
 


### PR DESCRIPTION
This will make bitcoin-kmp easier to use from bitcoin-lib and eclair. The biggest change is the definition of TaprootTweak, which has now a flat hierarchy (it was just unusable from Scala and I did not want to create a Scala clone for this flag).

We also upgrade secp256k1-kmp which now is based on secp256k1 0.2.0