### PR TITLE
Add weight() to TxIn and TxOut

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
@@ -150,6 +150,8 @@ public data class TxIn(
 
     public fun updateWitness(witness: ScriptWitness): TxIn = this.copy(witness = witness)
 
+    public fun weight(): Int = weight(this)
+
     @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     public companion object : BtcSerializer<TxIn>() {
         /* Setting nSequence to this value for every input in a transaction disables nLockTime. */
@@ -204,6 +206,12 @@ public data class TxIn(
 
         @JvmStatic
         public fun coinbase(script: List<ScriptElt>): TxIn = coinbase(Script.write(script))
+
+        @JvmStatic
+        public fun weight(txIn: TxIn, protocolVersion: Long = PROTOCOL_VERSION): Int {
+            val witnessWeight = if (txIn.hasWitness) ScriptWitness.write(txIn.witness, protocolVersion).size else 0
+            return 4 * write(txIn).size + witnessWeight
+        }
     }
 
     override fun serializer(): BtcSerializer<TxIn> = TxIn
@@ -222,6 +230,8 @@ public data class TxOut(@JvmField val amount: Satoshi, @JvmField val publicKeySc
     public fun updatePublicKeyScript(input: ByteArray): TxOut = updatePublicKeyScript(input.byteVector())
 
     public fun updatePublicKeyScript(input: List<ScriptElt>): TxOut = updatePublicKeyScript(Script.write(input))
+
+    public fun weight(): Int = weight(this)
 
     @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     public companion object : BtcSerializer<TxOut>() {
@@ -250,6 +260,12 @@ public data class TxOut(@JvmField val amount: Satoshi, @JvmField val publicKeySc
             require(t.amount in Satoshi(0L)..Satoshi.MAX_MONEY) { "invalid txout amount: ${t.amount}" }
             require(t.publicKeyScript.size() < Script.MAX_SCRIPT_ELEMENT_SIZE) { "public key script is ${t.publicKeyScript.size()} bytes, limit is ${Script.MAX_SCRIPT_ELEMENT_SIZE} bytes" }
         }
+
+        @JvmStatic
+        public fun totalSize(txOut: TxOut, protocolVersion: Long = PROTOCOL_VERSION): Int = write(txOut, protocolVersion).size
+
+        @JvmStatic
+        public fun weight(txOut: TxOut, protocolVersion: Long = PROTOCOL_VERSION): Int = 4 * totalSize(txOut, protocolVersion)
     }
 
     override fun serializer(): BtcSerializer<TxOut> = TxOut

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
@@ -459,7 +459,7 @@ public data class Transaction(
         @JvmStatic
         public fun weight(tx: Transaction, protocolVersion: Long = PROTOCOL_VERSION): Int {
             // Witness data uses 1 weight unit, while non-witness data uses 4 weight units.
-            // We thus serialize ones with witness data and 3 times without witness data.
+            // We thus serialize once with witness data and 3 times without witness data.
             return totalSize(tx, protocolVersion) + 3 * baseSize(tx, protocolVersion)
         }
 

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/reference/TransactionTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/reference/TransactionTestsCommon.kt
@@ -134,4 +134,26 @@ class TransactionTestsCommon {
         val count = process(tests.jsonArray, false)
         assertEquals(93, count)
     }
+
+    @Test
+    fun `input and output weights`() {
+        val publicKey1 = PublicKey.fromHex("03949633a194a43a310c5a593aada2f2d4a4e3c181880e2b396facfb2130a7f0b5")
+        val publicKey2 = PublicKey.fromHex("02cf5642ac302c004f429b1d9334ac3f93f65ae4df2fb6bf23af3a848166afc662")
+        val sig = ByteVector("f55bcf4c0650024f421bef9f47f9967fe3015b8ceeda8328185d0f2e73e8c30980e95282b1a73c8d30ceae3c40a9d6df952fd93ea027f6d2a41f6b21dcb1afbef37e81988e8f770cca")
+        val txId = ByteVector32("2f8dbf25b36aef3ab1c14c302e3d07fddd8a9d860126bc6a03e8533bb6a31cbe")
+
+        val p2wpkhInputNoWitness = TxIn(OutPoint(txId, 3), ByteVector.empty, 0)
+        val p2wpkhInputWithWitness = TxIn(OutPoint(txId, 3), ByteVector.empty, 0, Script.witnessPay2wpkh(publicKey1, sig))
+        // See https://bitcoin.stackexchange.com/questions/100159/what-is-the-size-and-weight-of-a-p2wpkh-input
+        assertEquals(p2wpkhInputNoWitness.weight(), 164)
+        assertEquals(p2wpkhInputWithWitness.weight(), 273)
+
+        val p2wpkhOutput = TxOut(Satoshi(150_000), Script.pay2wpkh(publicKey1))
+        val p2wshOutput = TxOut(Satoshi(150_000), Script.pay2wsh(Script.createMultiSigMofN(1, listOf(publicKey1, publicKey2))))
+        val p2trOutput = TxOut(Satoshi(150_000), Script.pay2tr(publicKey1.xOnly()))
+        // See https://bitcoin.stackexchange.com/questions/66428/what-is-the-size-of-different-bitcoin-transaction-types
+        assertEquals(p2wpkhOutput.weight(), 124)
+        assertEquals(p2wshOutput.weight(), 172)
+        assertEquals(p2trOutput.weight(), 172)
+    }
 }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/reference/TransactionTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/reference/TransactionTestsCommon.kt
@@ -94,8 +94,8 @@ class TransactionTestsCommon {
                     val tx = Transaction.read(serializedTransaction, Protocol.PROTOCOL_VERSION)
                     val result = try {
                         val isTxValid = kotlin.runCatching { Transaction.validate(tx) }.isSuccess
-                        if(testCase[2].jsonPrimitive.content == "BADTX") require(!isTxValid){ "$tx should be invalid"}
-                        if(testCase[2].jsonPrimitive.content != "BADTX") require(isTxValid){ "$tx should be valid"}
+                        if (testCase[2].jsonPrimitive.content == "BADTX") require(!isTxValid) { "$tx should be invalid" }
+                        if (testCase[2].jsonPrimitive.content != "BADTX") require(isTxValid) { "$tx should be valid" }
                         val verifyFlags = ScriptTestsCommon.parseScriptFlags(testCase[2].jsonPrimitive.content)
 
                         for (i in 0..tx.txIn.lastIndex) {
@@ -147,6 +147,10 @@ class TransactionTestsCommon {
         // See https://bitcoin.stackexchange.com/questions/100159/what-is-the-size-and-weight-of-a-p2wpkh-input
         assertEquals(p2wpkhInputNoWitness.weight(), 164)
         assertEquals(p2wpkhInputWithWitness.weight(), 273)
+
+        // This is similar to a lightning channel funding input.
+        val p2wshInputWithWitness = TxIn(OutPoint(txId, 3), ByteVector.empty, 0, Script.witnessMultiSigMofN(listOf(publicKey1, publicKey2), listOf(sig, sig)))
+        assertEquals(p2wshInputWithWitness.weight(), 386)
 
         val p2wpkhOutput = TxOut(Satoshi(150_000), Script.pay2wpkh(publicKey1))
         val p2wshOutput = TxOut(Satoshi(150_000), Script.pay2wsh(Script.createMultiSigMofN(1, listOf(publicKey1, publicKey2))))


### PR DESCRIPTION
This is useful when sharing on-chain fees in the interactive-tx protocol used in lightning for dual funding and splicing.