### PR TITLE
Use proper types for address and script conversion errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 group = "fr.acinq.bitcoin"
-version = "0.12.0"
+version = "0.13.0-SNAPSHOT"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Bitcoin.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Bitcoin.kt
@@ -16,7 +16,6 @@
 
 package fr.acinq.bitcoin
 
-import fr.acinq.bitcoin.utils.Either
 import kotlin.jvm.JvmStatic
 
 public const val MaxBlockSize: Int = 1000000
@@ -27,18 +26,74 @@ public fun <T> List<T>.updated(i: Int, t: T): List<T> = when (i) {
     else -> this.take(i) + t + this.drop(i + 1)
 }
 
-public sealed class InvalidAddress {
-    public object ChainHashMismatch : InvalidAddress()
-    public object InvalidBech32Address : InvalidAddress()
-    public data class InvalidWitnessVersion(val version: Int) : InvalidAddress()
-    public data class GenericError(val error: Throwable) : InvalidAddress()
+public sealed interface AddressToPublicKeyScriptResult {
+    public val result: List<ScriptElt>?
+    public val isSuccess: Boolean
+        get() = result != null
+    public val isFailure: Boolean
+        get() = !isSuccess
+
+    public data class Success(val script: List<ScriptElt>) : AddressToPublicKeyScriptResult {
+        override val result: List<ScriptElt>?
+            get() = script
+    }
+
+    public sealed class Failure : AddressToPublicKeyScriptResult, Throwable() {
+        override val result: List<ScriptElt>?
+            get() = null
+
+        public object ChainHashMismatch : Failure() {
+            override val message: String? get() = "chain hash mismatch"
+        }
+
+        public object InvalidBech32Address : Failure() {
+            override val message: String?
+                get() = "invalid bech32 address"
+        }
+
+        public data class InvalidWitnessVersion(val version: Int) : Failure() {
+            override val message: String?
+                get() = "invalid witness version $version"
+        }
+
+        public data class GenericFailure(val t: Throwable) : Failure() {
+            override val cause: Throwable?
+                get() = t
+        }
+    }
 }
 
-public sealed class InvalidPublicKeyScript {
-    public object InvalidChainHash : InvalidPublicKeyScript()
-    public object InvalidScript : InvalidPublicKeyScript()
-    public data class InvalidWitnessVersion(val version: Int) : InvalidPublicKeyScript()
-    public data class GenericError(val error: Throwable) : InvalidPublicKeyScript()
+public sealed interface AddressFromPublicKeyScriptResult {
+    public val result: String?
+    public val isSuccess: Boolean
+        get() = result != null
+    public val isFailure: Boolean
+        get() = !isSuccess
+
+    public data class Success(val address: String) : AddressFromPublicKeyScriptResult {
+        override val result: String?
+            get() = address
+    }
+
+    public sealed class Failure : AddressFromPublicKeyScriptResult, Throwable() {
+        override val result: String?
+            get() = null
+
+        public object InvalidChainHash : Failure() {
+            override val message: String?
+                get() = "invalid chain hash"
+        }
+
+        public object InvalidScript : Failure() {
+            override val message: String?
+                get() = "invalid script"
+        }
+
+        public data class GenericError(val t: Throwable) : Failure() {
+            override val cause: Throwable?
+                get() = t
+        }
+    }
 }
 
 public object Bitcoin {
@@ -71,24 +126,31 @@ public object Bitcoin {
     @JvmStatic
     public fun computeBIP84Address(pub: PublicKey, chainHash: ByteVector32): String = computeP2WpkhAddress(pub, chainHash)
 
+    /**
+     * Compute an address form a public key script
+     * @param chainHash chain hash (i.e. hash of the genesic block of the chain we're on)
+     * @param pubkeyScript public key script
+     */
     @JvmStatic
-    public fun addressFromPublicKeyScript(chainHash: ByteVector32, pubkeyScript: List<ScriptElt>): Either<InvalidPublicKeyScript, String> {
-        return try {
-            when {
+    public fun addressFromPublicKeyScript(chainHash: ByteVector32, pubkeyScript: List<ScriptElt>): AddressFromPublicKeyScriptResult {
+        try {
+            return when {
                 Script.isPay2pkh(pubkeyScript) -> {
-                    when (chainHash) {
-                        Block.LivenetGenesisBlock.hash -> Either.Right(Base58Check.encode(Base58.Prefix.PubkeyAddress, (pubkeyScript[2] as OP_PUSHDATA).data))
-                        Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Either.Right(Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, (pubkeyScript[2] as OP_PUSHDATA).data))
-                        else -> Either.Left(InvalidPublicKeyScript.InvalidChainHash)
+                    val prefix = when (chainHash) {
+                        Block.LivenetGenesisBlock.hash -> Base58.Prefix.PubkeyAddress
+                        Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Base58.Prefix.PubkeyAddressTestnet
+                        else -> return AddressFromPublicKeyScriptResult.Failure.InvalidChainHash
                     }
+                    AddressFromPublicKeyScriptResult.Success(Base58Check.encode(prefix, (pubkeyScript[2] as OP_PUSHDATA).data))
                 }
 
                 Script.isPay2sh(pubkeyScript) -> {
-                    when (chainHash) {
-                        Block.LivenetGenesisBlock.hash -> Either.Right(Base58Check.encode(Base58.Prefix.ScriptAddress, (pubkeyScript[1] as OP_PUSHDATA).data))
-                        Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Either.Right(Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, (pubkeyScript[1] as OP_PUSHDATA).data))
-                        else -> Either.Left(InvalidPublicKeyScript.InvalidChainHash)
+                    val prefix = when (chainHash) {
+                        Block.LivenetGenesisBlock.hash -> Base58.Prefix.ScriptAddress
+                        Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Base58.Prefix.ScriptAddressTestnet
+                        else -> return AddressFromPublicKeyScriptResult.Failure.InvalidChainHash
                     }
+                    AddressFromPublicKeyScriptResult.Success(Base58Check.encode(prefix, (pubkeyScript[1] as OP_PUSHDATA).data))
                 }
 
                 Script.isNativeWitnessScript(pubkeyScript) -> {
@@ -96,46 +158,48 @@ public object Bitcoin {
                     val witnessScript = (pubkeyScript[1] as OP_PUSHDATA).data.toByteArray()
                     when (pubkeyScript[0]) {
                         is OP_0 -> when {
-                            Script.isPay2wpkh(pubkeyScript) || Script.isPay2wsh(pubkeyScript) -> Either.Right(Bech32.encodeWitnessAddress(hrp, 0, witnessScript))
-                            else -> Either.Left(InvalidPublicKeyScript.InvalidScript)
+                            Script.isPay2wpkh(pubkeyScript) || Script.isPay2wsh(pubkeyScript) -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 0, witnessScript))
+                            else -> AddressFromPublicKeyScriptResult.Failure.InvalidScript
                         }
-                        is OP_1 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 1, witnessScript))
-                        is OP_2 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 2, witnessScript))
-                        is OP_3 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 3, witnessScript))
-                        is OP_4 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 4, witnessScript))
-                        is OP_5 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 5, witnessScript))
-                        is OP_6 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 6, witnessScript))
-                        is OP_7 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 7, witnessScript))
-                        is OP_8 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 8, witnessScript))
-                        is OP_9 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 9, witnessScript))
-                        is OP_10 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 10, witnessScript))
-                        is OP_11 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 11, witnessScript))
-                        is OP_12 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 12, witnessScript))
-                        is OP_13 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 13, witnessScript))
-                        is OP_14 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 14, witnessScript))
-                        is OP_15 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 15, witnessScript))
-                        is OP_16 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 16, witnessScript))
-                        else -> Either.Left(InvalidPublicKeyScript.InvalidScript)
+
+                        is OP_1 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 1, witnessScript))
+                        is OP_2 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 2, witnessScript))
+                        is OP_3 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 3, witnessScript))
+                        is OP_4 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 4, witnessScript))
+                        is OP_5 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 5, witnessScript))
+                        is OP_6 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 6, witnessScript))
+                        is OP_7 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 7, witnessScript))
+                        is OP_8 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 8, witnessScript))
+                        is OP_9 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 9, witnessScript))
+                        is OP_10 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 10, witnessScript))
+                        is OP_11 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 11, witnessScript))
+                        is OP_12 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 12, witnessScript))
+                        is OP_13 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 13, witnessScript))
+                        is OP_14 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 14, witnessScript))
+                        is OP_15 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 15, witnessScript))
+                        is OP_16 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 16, witnessScript))
+                        else -> AddressFromPublicKeyScriptResult.Failure.InvalidScript
                     }
                 }
 
-                else -> Either.Left(InvalidPublicKeyScript.InvalidScript)
+                else -> AddressFromPublicKeyScriptResult.Failure.InvalidScript
             }
-        } catch (e: Exception) {
-            Either.Left(InvalidPublicKeyScript.GenericError(e))
+        } catch (t: Throwable) {
+            return AddressFromPublicKeyScriptResult.Failure.GenericError(t)
         }
     }
 
     @JvmStatic
-    public fun addressFromPublicKeyScript(chainHash: ByteVector32, pubkeyScript: ByteArray): Either<InvalidPublicKeyScript, String> =
-        try {
+    public fun addressFromPublicKeyScript(chainHash: ByteVector32, pubkeyScript: ByteArray): AddressFromPublicKeyScriptResult {
+        return try {
             addressFromPublicKeyScript(chainHash, Script.parse(pubkeyScript))
-        } catch (e: Exception) {
-            Either.Left(InvalidPublicKeyScript.GenericError(e))
+        } catch (t: Throwable) {
+            AddressFromPublicKeyScriptResult.Failure.GenericError(t)
         }
+    }
 
     @JvmStatic
-    public fun addressToPublicKeyScript(chainHash: ByteVector32, address: String): Either<InvalidAddress, List<ScriptElt>> {
+    public fun addressToPublicKeyScript(chainHash: ByteVector32, address: String): AddressToPublicKeyScriptResult {
         val witnessVersions = mapOf(
             0.toByte() to OP_0,
             1.toByte() to OP_1,
@@ -160,18 +224,18 @@ public object Bitcoin {
             onSuccess = {
                 when {
                     it.first == Base58.Prefix.PubkeyAddressTestnet && (chainHash == Block.TestnetGenesisBlock.hash || chainHash == Block.RegtestGenesisBlock.hash || chainHash == Block.SignetGenesisBlock.hash) ->
-                        Either.Right(Script.pay2pkh(it.second))
+                        AddressToPublicKeyScriptResult.Success(Script.pay2pkh(it.second))
 
                     it.first == Base58.Prefix.PubkeyAddress && chainHash == Block.LivenetGenesisBlock.hash ->
-                        Either.Right(Script.pay2pkh(it.second))
+                        AddressToPublicKeyScriptResult.Success(Script.pay2pkh(it.second))
 
                     it.first == Base58.Prefix.ScriptAddressTestnet && (chainHash == Block.TestnetGenesisBlock.hash || chainHash == Block.RegtestGenesisBlock.hash || chainHash == Block.SignetGenesisBlock.hash) ->
-                        Either.Right(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
+                        AddressToPublicKeyScriptResult.Success(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
 
                     it.first == Base58.Prefix.ScriptAddress && chainHash == Block.LivenetGenesisBlock.hash ->
-                        Either.Right(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
+                        AddressToPublicKeyScriptResult.Success(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
 
-                    else -> Either.Left(InvalidAddress.ChainHashMismatch)
+                    else -> AddressToPublicKeyScriptResult.Failure.ChainHashMismatch
                 }
             },
             onFailure = { _ ->
@@ -179,17 +243,17 @@ public object Bitcoin {
                     onSuccess = {
                         val witnessVersion = witnessVersions[it.second]
                         when {
-                            witnessVersion == null -> Either.Left(InvalidAddress.InvalidWitnessVersion(it.second.toInt()))
-                            it.third.size != 20 && it.third.size != 32 -> Either.Left(InvalidAddress.InvalidBech32Address)
-                            it.first == "bc" && chainHash == Block.LivenetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
-                            it.first == "tb" && chainHash == Block.TestnetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
-                            it.first == "tb" && chainHash == Block.SignetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
-                            it.first == "bcrt" && chainHash == Block.RegtestGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
-                            else -> Either.Left(InvalidAddress.ChainHashMismatch)
+                            witnessVersion == null -> AddressToPublicKeyScriptResult.Failure.InvalidWitnessVersion(it.second.toInt())
+                            it.third.size != 20 && it.third.size != 32 -> AddressToPublicKeyScriptResult.Failure.InvalidBech32Address
+                            it.first == "bc" && chainHash == Block.LivenetGenesisBlock.hash -> AddressToPublicKeyScriptResult.Success(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "tb" && chainHash == Block.TestnetGenesisBlock.hash -> AddressToPublicKeyScriptResult.Success(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "tb" && chainHash == Block.SignetGenesisBlock.hash -> AddressToPublicKeyScriptResult.Success(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "bcrt" && chainHash == Block.RegtestGenesisBlock.hash -> AddressToPublicKeyScriptResult.Success(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            else -> AddressToPublicKeyScriptResult.Failure.ChainHashMismatch
                         }
                     },
                     onFailure = {
-                        Either.Left(InvalidAddress.GenericError(it))
+                        AddressToPublicKeyScriptResult.Failure.GenericFailure(it)
                     }
                 )
             }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Bitcoin.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Bitcoin.kt
@@ -16,6 +16,7 @@
 
 package fr.acinq.bitcoin
 
+import fr.acinq.bitcoin.utils.Either
 import kotlin.jvm.JvmStatic
 
 public const val MaxBlockSize: Int = 1000000
@@ -24,6 +25,20 @@ public fun <T> List<T>.updated(i: Int, t: T): List<T> = when (i) {
     0 -> listOf(t) + this.drop(1)
     this.lastIndex -> this.dropLast(1) + t
     else -> this.take(i) + t + this.drop(i + 1)
+}
+
+public sealed class InvalidAddress {
+    public object ChainHashMismatch : InvalidAddress()
+    public object InvalidBech32Address : InvalidAddress()
+    public data class InvalidWitnessVersion(val version: Int) : InvalidAddress()
+    public data class GenericError(val error: Throwable) : InvalidAddress()
+}
+
+public sealed class InvalidPublicKeyScript {
+    public object InvalidChainHash : InvalidPublicKeyScript()
+    public object InvalidScript : InvalidPublicKeyScript()
+    public data class InvalidWitnessVersion(val version: Int) : InvalidPublicKeyScript()
+    public data class GenericError(val error: Throwable) : InvalidPublicKeyScript()
 }
 
 public object Bitcoin {
@@ -57,70 +72,70 @@ public object Bitcoin {
     public fun computeBIP84Address(pub: PublicKey, chainHash: ByteVector32): String = computeP2WpkhAddress(pub, chainHash)
 
     @JvmStatic
-    public fun addressFromPublicKeyScript(chainHash: ByteVector32, pubkeyScript: List<ScriptElt>): String? {
+    public fun addressFromPublicKeyScript(chainHash: ByteVector32, pubkeyScript: List<ScriptElt>): Either<InvalidPublicKeyScript, String> {
         return try {
             when {
                 Script.isPay2pkh(pubkeyScript) -> {
-                    val prefix = when (chainHash) {
-                        Block.LivenetGenesisBlock.hash -> Base58.Prefix.PubkeyAddress
-                        Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Base58.Prefix.PubkeyAddressTestnet
-                        else -> error("invalid chain hash")
+                    when (chainHash) {
+                        Block.LivenetGenesisBlock.hash -> Either.Right(Base58Check.encode(Base58.Prefix.PubkeyAddress, (pubkeyScript[2] as OP_PUSHDATA).data))
+                        Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Either.Right(Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, (pubkeyScript[2] as OP_PUSHDATA).data))
+                        else -> Either.Left(InvalidPublicKeyScript.InvalidChainHash)
                     }
-                    Base58Check.encode(prefix, (pubkeyScript[2] as OP_PUSHDATA).data)
                 }
+
                 Script.isPay2sh(pubkeyScript) -> {
-                    val prefix = when (chainHash) {
-                        Block.LivenetGenesisBlock.hash -> Base58.Prefix.ScriptAddress
-                        Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Base58.Prefix.ScriptAddressTestnet
-                        else -> error("invalid chain hash")
+                    when (chainHash) {
+                        Block.LivenetGenesisBlock.hash -> Either.Right(Base58Check.encode(Base58.Prefix.ScriptAddress, (pubkeyScript[1] as OP_PUSHDATA).data))
+                        Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Either.Right(Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, (pubkeyScript[1] as OP_PUSHDATA).data))
+                        else -> Either.Left(InvalidPublicKeyScript.InvalidChainHash)
                     }
-                    Base58Check.encode(prefix, (pubkeyScript[1] as OP_PUSHDATA).data)
                 }
+
                 Script.isNativeWitnessScript(pubkeyScript) -> {
                     val hrp = Bech32.hrp(chainHash)
                     val witnessScript = (pubkeyScript[1] as OP_PUSHDATA).data.toByteArray()
                     when (pubkeyScript[0]) {
                         is OP_0 -> when {
-                            Script.isPay2wpkh(pubkeyScript) || Script.isPay2wsh(pubkeyScript) -> Bech32.encodeWitnessAddress(hrp, 0, witnessScript)
-                            else -> null
+                            Script.isPay2wpkh(pubkeyScript) || Script.isPay2wsh(pubkeyScript) -> Either.Right(Bech32.encodeWitnessAddress(hrp, 0, witnessScript))
+                            else -> Either.Left(InvalidPublicKeyScript.InvalidScript)
                         }
-                        is OP_1 -> Bech32.encodeWitnessAddress(hrp, 1, witnessScript)
-                        is OP_2 -> Bech32.encodeWitnessAddress(hrp, 2, witnessScript)
-                        is OP_3 -> Bech32.encodeWitnessAddress(hrp, 3, witnessScript)
-                        is OP_4 -> Bech32.encodeWitnessAddress(hrp, 4, witnessScript)
-                        is OP_5 -> Bech32.encodeWitnessAddress(hrp, 5, witnessScript)
-                        is OP_6 -> Bech32.encodeWitnessAddress(hrp, 6, witnessScript)
-                        is OP_7 -> Bech32.encodeWitnessAddress(hrp, 7, witnessScript)
-                        is OP_8 -> Bech32.encodeWitnessAddress(hrp, 8, witnessScript)
-                        is OP_9 -> Bech32.encodeWitnessAddress(hrp, 9, witnessScript)
-                        is OP_10 -> Bech32.encodeWitnessAddress(hrp, 10, witnessScript)
-                        is OP_11 -> Bech32.encodeWitnessAddress(hrp, 11, witnessScript)
-                        is OP_12 -> Bech32.encodeWitnessAddress(hrp, 12, witnessScript)
-                        is OP_13 -> Bech32.encodeWitnessAddress(hrp, 13, witnessScript)
-                        is OP_14 -> Bech32.encodeWitnessAddress(hrp, 14, witnessScript)
-                        is OP_15 -> Bech32.encodeWitnessAddress(hrp, 15, witnessScript)
-                        is OP_16 -> Bech32.encodeWitnessAddress(hrp, 16, witnessScript)
-                        else -> null
+                        is OP_1 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 1, witnessScript))
+                        is OP_2 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 2, witnessScript))
+                        is OP_3 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 3, witnessScript))
+                        is OP_4 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 4, witnessScript))
+                        is OP_5 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 5, witnessScript))
+                        is OP_6 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 6, witnessScript))
+                        is OP_7 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 7, witnessScript))
+                        is OP_8 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 8, witnessScript))
+                        is OP_9 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 9, witnessScript))
+                        is OP_10 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 10, witnessScript))
+                        is OP_11 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 11, witnessScript))
+                        is OP_12 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 12, witnessScript))
+                        is OP_13 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 13, witnessScript))
+                        is OP_14 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 14, witnessScript))
+                        is OP_15 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 15, witnessScript))
+                        is OP_16 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 16, witnessScript))
+                        else -> Either.Left(InvalidPublicKeyScript.InvalidScript)
                     }
                 }
-                else -> null
+
+                else -> Either.Left(InvalidPublicKeyScript.InvalidScript)
             }
         } catch (e: Exception) {
-            null
+            Either.Left(InvalidPublicKeyScript.GenericError(e))
         }
     }
 
     @JvmStatic
-    public fun addressFromPublicKeyScript(chainHash: ByteVector32, pubkeyScript: ByteArray): String? {
-        return try {
+    public fun addressFromPublicKeyScript(chainHash: ByteVector32, pubkeyScript: ByteArray): Either<InvalidPublicKeyScript, String> =
+        try {
             addressFromPublicKeyScript(chainHash, Script.parse(pubkeyScript))
         } catch (e: Exception) {
-            null
+            Either.Left(InvalidPublicKeyScript.GenericError(e))
         }
-    }
 
     @JvmStatic
-    public fun addressToPublicKeyScript(chainHash: ByteVector32, address: String): List<ScriptElt> {
+    public fun addressToPublicKeyScript(chainHash: ByteVector32, address: String): Either<InvalidAddress, List<ScriptElt>> {
         val witnessVersions = mapOf(
             0.toByte() to OP_0,
             1.toByte() to OP_1,
@@ -144,29 +159,37 @@ public object Bitcoin {
         return runCatching { Base58Check.decode(address) }.fold(
             onSuccess = {
                 when {
-                    it.first == Base58.Prefix.PubkeyAddressTestnet && (chainHash == Block.TestnetGenesisBlock.hash || chainHash == Block.RegtestGenesisBlock.hash || chainHash == Block.SignetGenesisBlock.hash) -> Script.pay2pkh(it.second)
-                    it.first == Base58.Prefix.PubkeyAddress && chainHash == Block.LivenetGenesisBlock.hash -> Script.pay2pkh(it.second)
-                    it.first == Base58.Prefix.ScriptAddressTestnet && (chainHash == Block.TestnetGenesisBlock.hash || chainHash == Block.RegtestGenesisBlock.hash || chainHash == Block.SignetGenesisBlock.hash) -> listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL)
-                    it.first == Base58.Prefix.ScriptAddress && chainHash == Block.LivenetGenesisBlock.hash -> listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL)
-                    else -> error("base58 address does not match our blockchain")
+                    it.first == Base58.Prefix.PubkeyAddressTestnet && (chainHash == Block.TestnetGenesisBlock.hash || chainHash == Block.RegtestGenesisBlock.hash || chainHash == Block.SignetGenesisBlock.hash) ->
+                        Either.Right(Script.pay2pkh(it.second))
+
+                    it.first == Base58.Prefix.PubkeyAddress && chainHash == Block.LivenetGenesisBlock.hash ->
+                        Either.Right(Script.pay2pkh(it.second))
+
+                    it.first == Base58.Prefix.ScriptAddressTestnet && (chainHash == Block.TestnetGenesisBlock.hash || chainHash == Block.RegtestGenesisBlock.hash || chainHash == Block.SignetGenesisBlock.hash) ->
+                        Either.Right(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
+
+                    it.first == Base58.Prefix.ScriptAddress && chainHash == Block.LivenetGenesisBlock.hash ->
+                        Either.Right(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
+
+                    else -> Either.Left(InvalidAddress.ChainHashMismatch)
                 }
             },
-            onFailure = { base58error ->
+            onFailure = { _ ->
                 runCatching { Bech32.decodeWitnessAddress(address) }.fold(
                     onSuccess = {
                         val witnessVersion = witnessVersions[it.second]
                         when {
-                            witnessVersion == null -> error("invalid version ${it.second} in bech32 address")
-                            it.third.size != 20 && it.third.size != 32 -> error("hash length in bech32 address must be either 20 or 32 bytes")
-                            it.first == "bc" && chainHash == Block.LivenetGenesisBlock.hash -> listOf(witnessVersion, OP_PUSHDATA(it.third))
-                            it.first == "tb" && chainHash == Block.TestnetGenesisBlock.hash -> listOf(witnessVersion, OP_PUSHDATA(it.third))
-                            it.first == "tb" && chainHash == Block.SignetGenesisBlock.hash -> listOf(witnessVersion, OP_PUSHDATA(it.third))
-                            it.first == "bcrt" && chainHash == Block.RegtestGenesisBlock.hash -> listOf(witnessVersion, OP_PUSHDATA(it.third))
-                            else -> error("bech32 address does not match our blockchain")
+                            witnessVersion == null -> Either.Left(InvalidAddress.InvalidWitnessVersion(it.second.toInt()))
+                            it.third.size != 20 && it.third.size != 32 -> Either.Left(InvalidAddress.InvalidBech32Address)
+                            it.first == "bc" && chainHash == Block.LivenetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "tb" && chainHash == Block.TestnetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "tb" && chainHash == Block.SignetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "bcrt" && chainHash == Block.RegtestGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            else -> Either.Left(InvalidAddress.ChainHashMismatch)
                         }
                     },
                     onFailure = {
-                        error("$address is neither a valid Base58 address ($base58error) nor a valid Bech32 address ($it)")
+                        Either.Left(InvalidAddress.GenericError(it))
                     }
                 )
             }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/BIP86TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/BIP86TestsCommon.kt
@@ -23,7 +23,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey.value, ByteVector32("a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"))
         val script = listOf(OP_1, OP_PUSHDATA(outputKey.value))
         assertEquals(Script.write(script).byteVector(), ByteVector("5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script), "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr")
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right, "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr")
 
         val key1 = DeterministicWallet.derivePrivateKey(accountKey, listOf(0L, 1L))
         assertEquals(key1.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/0/1")).secretkeybytes)
@@ -33,7 +33,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey1.value, ByteVector32("a82f29944d65b86ae6b5e5cc75e294ead6c59391a1edc5e016e3498c67fc7bbb"))
         val script1 = listOf(OP_1, OP_PUSHDATA(outputKey1.value))
         assertEquals(Script.write(script1).byteVector(), ByteVector("5120a82f29944d65b86ae6b5e5cc75e294ead6c59391a1edc5e016e3498c67fc7bbb"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script1), "bc1p4qhjn9zdvkux4e44uhx8tc55attvtyu358kutcqkudyccelu0was9fqzwh")
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script1).right, "bc1p4qhjn9zdvkux4e44uhx8tc55attvtyu358kutcqkudyccelu0was9fqzwh")
 
         val key2 = DeterministicWallet.derivePrivateKey(accountKey, listOf(1L, 0L))
         assertEquals(key2.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/1/0")).secretkeybytes)
@@ -43,7 +43,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey2.value, ByteVector32("882d74e5d0572d5a816cef0041a96b6c1de832f6f9676d9605c44d5e9a97d3dc"))
         val script2 = listOf(OP_1, OP_PUSHDATA(outputKey2.value))
         assertEquals(Script.write(script2).byteVector(), ByteVector("5120882d74e5d0572d5a816cef0041a96b6c1de832f6f9676d9605c44d5e9a97d3dc"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script2), "bc1p3qkhfews2uk44qtvauqyr2ttdsw7svhkl9nkm9s9c3x4ax5h60wqwruhk7")
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script2).right, "bc1p3qkhfews2uk44qtvauqyr2ttdsw7svhkl9nkm9s9c3x4ax5h60wqwruhk7")
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/BIP86TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/BIP86TestsCommon.kt
@@ -23,7 +23,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey.value, ByteVector32("a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"))
         val script = listOf(OP_1, OP_PUSHDATA(outputKey.value))
         assertEquals(Script.write(script).byteVector(), ByteVector("5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right, "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr")
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script), AddressFromPublicKeyScriptResult.Success("bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr"))
 
         val key1 = DeterministicWallet.derivePrivateKey(accountKey, listOf(0L, 1L))
         assertEquals(key1.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/0/1")).secretkeybytes)
@@ -33,7 +33,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey1.value, ByteVector32("a82f29944d65b86ae6b5e5cc75e294ead6c59391a1edc5e016e3498c67fc7bbb"))
         val script1 = listOf(OP_1, OP_PUSHDATA(outputKey1.value))
         assertEquals(Script.write(script1).byteVector(), ByteVector("5120a82f29944d65b86ae6b5e5cc75e294ead6c59391a1edc5e016e3498c67fc7bbb"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script1).right, "bc1p4qhjn9zdvkux4e44uhx8tc55attvtyu358kutcqkudyccelu0was9fqzwh")
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script1), AddressFromPublicKeyScriptResult.Success("bc1p4qhjn9zdvkux4e44uhx8tc55attvtyu358kutcqkudyccelu0was9fqzwh"))
 
         val key2 = DeterministicWallet.derivePrivateKey(accountKey, listOf(1L, 0L))
         assertEquals(key2.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/1/0")).secretkeybytes)
@@ -43,7 +43,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey2.value, ByteVector32("882d74e5d0572d5a816cef0041a96b6c1de832f6f9676d9605c44d5e9a97d3dc"))
         val script2 = listOf(OP_1, OP_PUSHDATA(outputKey2.value))
         assertEquals(Script.write(script2).byteVector(), ByteVector("5120882d74e5d0572d5a816cef0041a96b6c1de832f6f9676d9605c44d5e9a97d3dc"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script2).right, "bc1p3qkhfews2uk44qtvauqyr2ttdsw7svhkl9nkm9s9c3x4ax5h60wqwruhk7")
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script2), AddressFromPublicKeyScriptResult.Success("bc1p3qkhfews2uk44qtvauqyr2ttdsw7svhkl9nkm9s9c3x4ax5h60wqwruhk7"))
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/BitcoinTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/BitcoinTestsCommon.kt
@@ -5,7 +5,6 @@ import fr.acinq.bitcoin.Bitcoin.addressToPublicKeyScript
 import fr.acinq.bitcoin.Bitcoin.computeP2PkhAddress
 import fr.acinq.bitcoin.Bitcoin.computeP2ShOfP2WpkhAddress
 import fr.acinq.bitcoin.Bitcoin.computeP2WpkhAddress
-import fr.acinq.bitcoin.utils.Either
 import fr.acinq.secp256k1.Hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -37,13 +36,13 @@ class BitcoinTestsCommon {
         fun address(script: List<ScriptElt>, chainHash: ByteVector32) = addressFromPublicKeyScript(chainHash, script)
 
         listOf(Block.LivenetGenesisBlock.hash, Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash).forEach {
-            assertEquals(address(Script.pay2pkh(pub), it).right, computeP2PkhAddress(pub, it))
-            assertEquals(address(Script.pay2wpkh(pub), it).right, computeP2WpkhAddress(pub, it))
-            assertEquals(address(Script.pay2sh(Script.pay2wpkh(pub)), it).right, computeP2ShOfP2WpkhAddress(pub, it))
+            assertEquals(address(Script.pay2pkh(pub), it).result, computeP2PkhAddress(pub, it))
+            assertEquals(address(Script.pay2wpkh(pub), it).result, computeP2WpkhAddress(pub, it))
+            assertEquals(address(Script.pay2sh(Script.pay2wpkh(pub)), it).result, computeP2ShOfP2WpkhAddress(pub, it))
             // all these chain hashes are invalid
-            assertTrue(address(Script.pay2pkh(pub), it.reversed()).isLeft)
-            assertTrue(address(Script.pay2wpkh(pub), it.reversed()).isLeft)
-            assertTrue(address(Script.pay2sh(Script.pay2wpkh(pub)), it.reversed()).isLeft)
+            assertTrue(address(Script.pay2pkh(pub), it.reversed()).isFailure)
+            assertTrue(address(Script.pay2wpkh(pub), it.reversed()).isFailure)
+            assertTrue(address(Script.pay2sh(Script.pay2wpkh(pub)), it.reversed()).isFailure)
         }
 
         listOf(
@@ -56,7 +55,7 @@ class BitcoinTestsCommon {
             Triple("76a914536ffa992491508dca0354e52f32a3a7a679a53a88ac", Block.LivenetGenesisBlock.hash, "18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX"),
             Triple("a91481b9ac6a59b53927da7277b5ad5460d781b365d987", Block.LivenetGenesisBlock.hash, "3DWwX7NYjnav66qygrm4mBCpiByjammaWy"),
         ).forEach {
-            assertEquals(addressFromPublicKeyScript(it.second, Hex.decode(it.first)).right, it.third)
+            assertEquals(addressFromPublicKeyScript(it.second, Hex.decode(it.first)).result, it.third)
         }
     }
 
@@ -66,31 +65,31 @@ class BitcoinTestsCommon {
 
         // p2pkh
         // valid chain
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, pub.hash160())), Either.Right(Script.pay2pkh(pub)))
-        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, pub.hash160())), Either.Right(Script.pay2pkh(pub)))
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, pub.hash160())), Either.Right(Script.pay2pkh(pub)))
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), Either.Right(Script.pay2pkh(pub)))
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, pub.hash160())), AddressToPublicKeyScriptResult.Success(Script.pay2pkh(pub)))
+        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, pub.hash160())), AddressToPublicKeyScriptResult.Success((Script.pay2pkh(pub))))
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, pub.hash160())), AddressToPublicKeyScriptResult.Success(Script.pay2pkh(pub)))
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), AddressToPublicKeyScriptResult.Success(Script.pay2pkh(pub)))
 
         // wrong chain
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), Either.Left(InvalidAddress.ChainHashMismatch))
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
 
         // p2sh
         val script = Script.write(Script.pay2wpkh(pub))
 
         // valid chain
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))), Either.Right(Script.pay2sh(script)))
-        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))), Either.Right(Script.pay2sh(script)))
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))), Either.Right(Script.pay2sh(script)))
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))), Either.Right(Script.pay2sh(script)))
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))), AddressToPublicKeyScriptResult.Success(Script.pay2sh(script)))
+        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))), AddressToPublicKeyScriptResult.Success(Script.pay2sh(script)))
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))), AddressToPublicKeyScriptResult.Success(Script.pay2sh(script)))
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))), AddressToPublicKeyScriptResult.Success(Script.pay2sh(script)))
 
         // wrong chain
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))), Either.Left(InvalidAddress.ChainHashMismatch))
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
     }
 
     @Test
@@ -98,22 +97,22 @@ class BitcoinTestsCommon {
         val pub = PrivateKey.fromHex("0101010101010101010101010101010101010101010101010101010101010101").publicKey()
 
         // p2wpkh
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())), Either.Right(Script.pay2wpkh(pub)))
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, pub.hash160())), Either.Right(Script.pay2wpkh(pub)))
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, pub.hash160())), Either.Right(Script.pay2wpkh(pub)))
-        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, pub.hash160())), Either.Right(Script.pay2wpkh(pub)))
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())), AddressToPublicKeyScriptResult.Success(Script.pay2wpkh(pub)))
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, pub.hash160())), AddressToPublicKeyScriptResult.Success(Script.pay2wpkh(pub)))
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, pub.hash160())), AddressToPublicKeyScriptResult.Success(Script.pay2wpkh(pub)))
+        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, pub.hash160())), AddressToPublicKeyScriptResult.Success(Script.pay2wpkh(pub)))
 
         // wrong chain
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, pub.hash160())), Either.Left(InvalidAddress.ChainHashMismatch))
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, pub.hash160())), Either.Left(InvalidAddress.ChainHashMismatch))
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, pub.hash160())), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, pub.hash160())), AddressToPublicKeyScriptResult.Failure.ChainHashMismatch)
 
         val script = Script.write(Script.pay2wpkh(pub))
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, Crypto.sha256(script))), Either.Right(Script.pay2wsh(script)))
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, Crypto.sha256(script))), Either.Right(Script.pay2wsh(script)))
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, Crypto.sha256(script))), Either.Right(Script.pay2wsh(script)))
-        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, Crypto.sha256(script))), Either.Right(Script.pay2wsh(script)))
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, Crypto.sha256(script))), AddressToPublicKeyScriptResult.Success(Script.pay2wsh(script)))
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, Crypto.sha256(script))), AddressToPublicKeyScriptResult.Success(Script.pay2wsh(script)))
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, Crypto.sha256(script))), AddressToPublicKeyScriptResult.Success(Script.pay2wsh(script)))
+        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, Crypto.sha256(script))), AddressToPublicKeyScriptResult.Success(Script.pay2wsh(script)))
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/ScriptTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/ScriptTestsCommon.kt
@@ -30,7 +30,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2pkh(script))
         assertNull(Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wpkh(script) || Script.isPay2wsh(script))
-        assertEquals("1C6Rc3w25VHud3dLDamutaqfKWqhrLRTaD", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
+        assertEquals("1C6Rc3w25VHud3dLDamutaqfKWqhrLRTaD", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
     }
 
     @Test
@@ -40,7 +40,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2sh(script))
         assertNull(Script.getWitnessVersion(script))
         assertFalse(Script.isPay2pkh(script) || Script.isPay2wpkh(script) || Script.isPay2wsh(script))
-        assertEquals("3DedZ8SErqfunkjqnv8Pta1MKgEuHi22W5", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
+        assertEquals("3DedZ8SErqfunkjqnv8Pta1MKgEuHi22W5", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
     }
 
     @Test
@@ -50,7 +50,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2wpkh(script))
         assertEquals(0, Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2pkh(script) || Script.isPay2wsh(script))
-        assertEquals("bc1q0xcqpzrky6eff2g52qdye53xkk9jxkvrh6yhyw", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
+        assertEquals("bc1q0xcqpzrky6eff2g52qdye53xkk9jxkvrh6yhyw", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
     }
 
     @Test
@@ -60,7 +60,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2wsh(script))
         assertEquals(0, Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wpkh(script) || Script.isPay2pkh(script))
-        assertEquals("bc1qdudnf8tla4fyptt3n9y9985tq64lqwzr37d4ywpqfzfhtt638glsqaednx", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
+        assertEquals("bc1qdudnf8tla4fyptt3n9y9985tq64lqwzr37d4ywpqfzfhtt638glsqaednx", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
     }
 
     @Test
@@ -70,7 +70,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isNativeWitnessScript(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wsh(script) || Script.isPay2wpkh(script) || Script.isPay2pkh(script))
         assertEquals(1, Script.getWitnessVersion(script))
-        assertEquals("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
+        assertEquals("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/ScriptTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/ScriptTestsCommon.kt
@@ -30,7 +30,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2pkh(script))
         assertNull(Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wpkh(script) || Script.isPay2wsh(script))
-        assertEquals("1C6Rc3w25VHud3dLDamutaqfKWqhrLRTaD", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script))
+        assertEquals("1C6Rc3w25VHud3dLDamutaqfKWqhrLRTaD", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test
@@ -40,7 +40,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2sh(script))
         assertNull(Script.getWitnessVersion(script))
         assertFalse(Script.isPay2pkh(script) || Script.isPay2wpkh(script) || Script.isPay2wsh(script))
-        assertEquals("3DedZ8SErqfunkjqnv8Pta1MKgEuHi22W5", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script))
+        assertEquals("3DedZ8SErqfunkjqnv8Pta1MKgEuHi22W5", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test
@@ -50,7 +50,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2wpkh(script))
         assertEquals(0, Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2pkh(script) || Script.isPay2wsh(script))
-        assertEquals("bc1q0xcqpzrky6eff2g52qdye53xkk9jxkvrh6yhyw", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script))
+        assertEquals("bc1q0xcqpzrky6eff2g52qdye53xkk9jxkvrh6yhyw", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test
@@ -60,7 +60,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2wsh(script))
         assertEquals(0, Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wpkh(script) || Script.isPay2pkh(script))
-        assertEquals("bc1qdudnf8tla4fyptt3n9y9985tq64lqwzr37d4ywpqfzfhtt638glsqaednx", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script))
+        assertEquals("bc1qdudnf8tla4fyptt3n9y9985tq64lqwzr37d4ywpqfzfhtt638glsqaednx", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test
@@ -70,7 +70,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isNativeWitnessScript(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wsh(script) || Script.isPay2wpkh(script) || Script.isPay2pkh(script))
         assertEquals(1, Script.getWitnessVersion(script))
-        assertEquals("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script))
+        assertEquals("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
@@ -84,7 +84,7 @@ class TaprootTestsCommon {
         assertEquals(Script.pay2tr(outputKey), Script.parse(tx.txOut[1].publicKeyScript))
 
         // we want to spend
-        val outputScript = addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, "tb1pn3g330w4n5eut7d4vxq0pp303267qc6vg8d2e0ctjuqre06gs3yqnc5yx0")
+        val outputScript = addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, "tb1pn3g330w4n5eut7d4vxq0pp303267qc6vg8d2e0ctjuqre06gs3yqnc5yx0").right!!
         val tx1 = Transaction(
             2,
             listOf(TxIn(OutPoint(tx, 1), TxIn.SEQUENCE_FINAL)),
@@ -188,7 +188,7 @@ class TaprootTestsCommon {
         val tmp = Transaction(
             version = 2,
             txIn = listOf(TxIn(OutPoint(fundingTx, 0), TxIn.SEQUENCE_FINAL)),
-            txOut = listOf(TxOut(fundingTx.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, "bcrt1qdtu5cwyngza8hw8s5uk2erlrkh8ceh3msp768v"))),
+            txOut = listOf(TxOut(fundingTx.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, "bcrt1qdtu5cwyngza8hw8s5uk2erlrkh8ceh3msp768v").right!!)),
             lockTime = 0
         )
         val hash = hashForSigningSchnorr(tmp, 0, listOf(fundingTx.txOut[0]), SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPSCRIPT, Script.ExecutionData(annex = null, tapleafHash = merkleRoot))
@@ -247,14 +247,14 @@ class TaprootTestsCommon {
         val script = Script.write(listOf(OP_1, OP_PUSHDATA(tweakedKey.value))).byteVector()
         val bip350Address = Bech32.encodeWitnessAddress(hrp(blockchain), 1.toByte(), tweakedKey.value.toByteArray())
         assertEquals(bip350Address, "tb1p78gx95syx0qz8w5nftk8t7nce78zlpqpsxugcvq5xpfy4tvn6rasd7wk0y")
-        val sweepPublicKeyScript = addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7")
+        val sweepPublicKeyScript = addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").right!!
 
         // see https://mempool.space/signet/tx/c284010f06b5182e9f4722ce3474980339b1fc76e5ff29ece812f5d2162595c1
         val fundingTx = Transaction.read("020000000001017034061243a7770f791aa2afdb118be900f4f8fc755a36d8632213acc139bab20100000000feffffff0200e1f50500000000225120f1d062d20433c023ba934aec75fa78cf8e2f840181b88c301430524aad93d0fbc192ac1700000000160014b66f2e807b9f4adecb99ad811dde501ca3f0fd5f02473044022046a2fd077e12b1d7ba74f6e7ac469deb3e3755c100216abad667980fc39463dc022018b63cfaf72fde0b5ca10c617aeaa0015013bd06ef08f82eea500c6467d963cc0121030b50ec81d958ae79d34d3579faf72456213d7d581a908e2b64d21b96777882043ab10100")
 
         // output #1 is the one we want to spend
         assertEquals(fundingTx.txOut[0].publicKeyScript, script)
-        assertEquals(addressToPublicKeyScript(blockchain, bip350Address), listOf(OP_1, OP_PUSHDATA(tweakedKey.value)))
+        assertEquals(addressToPublicKeyScript(blockchain, bip350Address).right, listOf(OP_1, OP_PUSHDATA(tweakedKey.value)))
 
         // spending with the key path: no need to provide any script
         val tx = run {
@@ -336,7 +336,7 @@ class TaprootTestsCommon {
             val tmp = Transaction(
                 version = 2,
                 txIn = listOf(TxIn(OutPoint(fundingTx3, 1), TxIn.SEQUENCE_FINAL)),
-                txOut = listOf(TxOut(fundingTx3.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7"))),
+                txOut = listOf(TxOut(fundingTx3.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").right!!)),
                 lockTime = 0
             )
             // to re-compute the merkle root we need to provide branch(#1, #2)

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
@@ -84,7 +84,7 @@ class TaprootTestsCommon {
         assertEquals(Script.pay2tr(outputKey), Script.parse(tx.txOut[1].publicKeyScript))
 
         // we want to spend
-        val outputScript = addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, "tb1pn3g330w4n5eut7d4vxq0pp303267qc6vg8d2e0ctjuqre06gs3yqnc5yx0").right!!
+        val outputScript = addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, "tb1pn3g330w4n5eut7d4vxq0pp303267qc6vg8d2e0ctjuqre06gs3yqnc5yx0").result!!
         val tx1 = Transaction(
             2,
             listOf(TxIn(OutPoint(tx, 1), TxIn.SEQUENCE_FINAL)),
@@ -188,7 +188,7 @@ class TaprootTestsCommon {
         val tmp = Transaction(
             version = 2,
             txIn = listOf(TxIn(OutPoint(fundingTx, 0), TxIn.SEQUENCE_FINAL)),
-            txOut = listOf(TxOut(fundingTx.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, "bcrt1qdtu5cwyngza8hw8s5uk2erlrkh8ceh3msp768v").right!!)),
+            txOut = listOf(TxOut(fundingTx.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, "bcrt1qdtu5cwyngza8hw8s5uk2erlrkh8ceh3msp768v").result!!)),
             lockTime = 0
         )
         val hash = hashForSigningSchnorr(tmp, 0, listOf(fundingTx.txOut[0]), SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPSCRIPT, Script.ExecutionData(annex = null, tapleafHash = merkleRoot))
@@ -247,14 +247,14 @@ class TaprootTestsCommon {
         val script = Script.write(listOf(OP_1, OP_PUSHDATA(tweakedKey.value))).byteVector()
         val bip350Address = Bech32.encodeWitnessAddress(hrp(blockchain), 1.toByte(), tweakedKey.value.toByteArray())
         assertEquals(bip350Address, "tb1p78gx95syx0qz8w5nftk8t7nce78zlpqpsxugcvq5xpfy4tvn6rasd7wk0y")
-        val sweepPublicKeyScript = addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").right!!
+        val sweepPublicKeyScript = addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").result!!
 
         // see https://mempool.space/signet/tx/c284010f06b5182e9f4722ce3474980339b1fc76e5ff29ece812f5d2162595c1
         val fundingTx = Transaction.read("020000000001017034061243a7770f791aa2afdb118be900f4f8fc755a36d8632213acc139bab20100000000feffffff0200e1f50500000000225120f1d062d20433c023ba934aec75fa78cf8e2f840181b88c301430524aad93d0fbc192ac1700000000160014b66f2e807b9f4adecb99ad811dde501ca3f0fd5f02473044022046a2fd077e12b1d7ba74f6e7ac469deb3e3755c100216abad667980fc39463dc022018b63cfaf72fde0b5ca10c617aeaa0015013bd06ef08f82eea500c6467d963cc0121030b50ec81d958ae79d34d3579faf72456213d7d581a908e2b64d21b96777882043ab10100")
 
         // output #1 is the one we want to spend
         assertEquals(fundingTx.txOut[0].publicKeyScript, script)
-        assertEquals(addressToPublicKeyScript(blockchain, bip350Address).right, listOf(OP_1, OP_PUSHDATA(tweakedKey.value)))
+        assertEquals(addressToPublicKeyScript(blockchain, bip350Address).result, listOf(OP_1, OP_PUSHDATA(tweakedKey.value)))
 
         // spending with the key path: no need to provide any script
         val tx = run {
@@ -336,7 +336,7 @@ class TaprootTestsCommon {
             val tmp = Transaction(
                 version = 2,
                 txIn = listOf(TxIn(OutPoint(fundingTx3, 1), TxIn.SEQUENCE_FINAL)),
-                txOut = listOf(TxOut(fundingTx3.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").right!!)),
+                txOut = listOf(TxOut(fundingTx3.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").result!!)),
                 lockTime = 0
             )
             // to re-compute the merkle root we need to provide branch(#1, #2)


### PR DESCRIPTION
We add specific return types to handle invalid address and public key script conversions. 
This is better than throwing exceptions because it makes easier for clients to create their own error handling code with localized error messages.