### PR TITLE
Change how taproot merkle proofs are built

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Script.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Script.kt
@@ -487,13 +487,19 @@ public object Script {
     /**
      * @param internalKey internal public key that will be tweaked with the [scripts] provided.
      * @param scripts optional spending scripts that can be used instead of key-path spending.
-     * @return the script and the tweak that must be applied to the private key for [internalKey] when signing.
      */
     @JvmStatic
-    public fun pay2tr(internalKey: XonlyPublicKey, scripts: ScriptTree?): List<ScriptElt> {
-        val tweak = when (scripts) {
+    public fun pay2tr(internalKey: XonlyPublicKey, scripts: ScriptTree?): List<ScriptElt> = pay2tr(internalKey, scripts?.hash())
+
+    /**
+     * @param internalKey internal public key that will be tweaked with the [scriptsRoot] provided.
+     * @param scriptsRoot optional merkle root of the spending scripts that can be used instead of key-path spending.
+     */
+    @JvmStatic
+    public fun pay2tr(internalKey: XonlyPublicKey, scriptsRoot: ByteVector32?): List<ScriptElt> {
+        val tweak = when (scriptsRoot) {
             null -> Crypto.TaprootTweak.NoScriptTweak
-            else -> Crypto.TaprootTweak.ScriptTweak(scripts.hash())
+            else -> Crypto.TaprootTweak.ScriptTweak(scriptsRoot)
         }
         val (publicKey, _) = internalKey.outputKey(tweak)
         return pay2tr(publicKey)

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Script.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Script.kt
@@ -675,6 +675,19 @@ public object Script {
             val merkleProof = scriptTree.merkleProof(spendingScript.id).tail()
             return ByteVector.empty.concat(controlByte).concat(internalPubKey.value).concat(merkleProof)
         }
+
+        /**
+         * @param internalPubKey internal public key.
+         * @param merkleRoot merkle root of the tapscript tree.
+         * @param merkleProof merkle proof of the spent script leaf: must not contain the script leaf nor the merkle root.
+         * @param leafVersion script version of the spent script leaf.
+         */
+        @JvmStatic
+        public fun build(internalPubKey: XonlyPublicKey, merkleRoot: ByteVector32, merkleProof: List<ByteVector32>, leafVersion: Int): ByteVector {
+            val (_, parity) = internalPubKey.outputKey(merkleRoot)
+            val controlByte = (leafVersion + (if (parity) 1 else 0)).toByte()
+            return ByteVector.empty.concat(controlByte).concat(internalPubKey.value).concat(merkleProof)
+        }
     }
 
     public class Runner(

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/ScriptTree.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/ScriptTree.kt
@@ -16,45 +16,73 @@
 package fr.acinq.bitcoin
 
 import fr.acinq.bitcoin.io.ByteArrayOutput
-import kotlin.jvm.JvmStatic
 
-/**
- * leaf of a script tree used to create and spend tapscript transactions
- * @param id leaf id
- * @param script serialized bitcoin script
- * @param leafVersion tapscript version
- */
-public data class ScriptLeaf(val id: Int, val script: ByteVector, val leafVersion: Int) {
-    public constructor(id: Int, script: List<ScriptElt>, leafVersion: Int) : this(id, Script.write(script).byteVector(), leafVersion)
+/** Simple binary tree structure containing taproot spending scripts. */
+public sealed class ScriptTree {
     /**
-     * tapleaf hash of this leaf
+     * Multiple spending scripts can be placed in the leaves of a taproot tree. When using one of those scripts to spend
+     * funds, we only need to reveal that specific script and a merkle proof that it is a leaf of the tree.
+     *
+     * @param id id that isn't used in the hash, but can be used by the caller to reference specific scripts.
+     * @param script serialized spending script.
+     * @param leafVersion tapscript version.
      */
-    val hash: ByteVector32 = run {
-        val buffer = ByteArrayOutput()
-        buffer.write(leafVersion)
-        BtcSerializer.writeScript(script, buffer)
-        Crypto.taggedHash(buffer.toByteArray(), "TapLeaf")
+    public data class Leaf(val id: Int, val script: ByteVector, val leafVersion: Int) : ScriptTree() {
+        public constructor(id: Int, script: List<ScriptElt>) : this(id, script, Script.TAPROOT_LEAF_TAPSCRIPT)
+        public constructor(id: Int, script: List<ScriptElt>, leafVersion: Int) : this(id, Script.write(script).byteVector(), leafVersion)
     }
-}
 
-/**
- * Simple binary tree structure
- */
-public sealed class ScriptTree<T> {
-    public data class Leaf<T>(val value: T) : ScriptTree<T>()
-    public data class Branch<T>(val left: ScriptTree<T>, val right: ScriptTree<T>) : ScriptTree<T>()
+    public data class Branch(val left: ScriptTree, val right: ScriptTree) : ScriptTree()
 
-    public companion object {
-        /**
-         * @return the hash of the input merkle tree
-         */
-        @JvmStatic
-        public fun hash(tree: ScriptTree<ScriptLeaf>): ByteVector32 = when (tree) {
-            is Leaf -> tree.value.hash
+    /** Compute the merkle root of the script tree. */
+    public fun hash(): ByteVector32 = when (this) {
+        is Leaf -> {
+            val buffer = ByteArrayOutput()
+            buffer.write(this.leafVersion)
+            BtcSerializer.writeScript(this.script, buffer)
+            Crypto.taggedHash(buffer.toByteArray(), "TapLeaf")
+        }
+        is Branch -> {
+            val h1 = this.left.hash()
+            val h2 = this.right.hash()
+            val toHash = if (LexicographicalOrdering.isLessThan(h1, h2)) h1 + h2 else h2 + h1
+            Crypto.taggedHash(toHash.toByteArray(), "TapBranch")
+        }
+    }
+
+    /** Return the first script leaf with the corresponding id, if any. */
+    public fun findScript(id: Int): Leaf? = when (this) {
+        is Leaf -> if (this.id == id) this else null
+        is Branch -> this.left.findScript(id) ?: this.right.findScript(id)
+    }
+
+    /**
+     * Compute a merkle proof for the given script leaf.
+     * Note that this proof starts with the target leaf at the beginning of the resulting list.
+     * Callers may need to drop that element in some cases.
+     */
+    public fun merkleProof(leafId: Int): List<ByteVector32> {
+        return when (this) {
+            is Leaf -> when (this.id) {
+                // We found our leaf: we can now walk up the tree to build the rest of the proof.
+                leafId -> listOf(this.hash())
+                // We reached a leaf that doesn't match our target: we're not on the right path.
+                else -> listOf()
+            }
             is Branch -> {
-                val h1 = hash(tree.left)
-                val h2 = hash(tree.right)
-                Crypto.taggedHash((if (LexicographicalOrdering.isLessThan(h1, h2)) h1 + h2 else h2 + h1).toByteArray(), "TapBranch")
+                val leftProof = this.left.merkleProof(leafId)
+                if (leftProof.isNotEmpty()) {
+                    // Our target leaf is in that subtree: we add its sibling to the proof.
+                    leftProof + this.right.hash()
+                } else {
+                    val rightProof = this.right.merkleProof(leafId)
+                    if (rightProof.isNotEmpty()) {
+                        // Our target leaf is in that subtree: we add its sibling to the proof.
+                        rightProof + this.left.hash()
+                    } else {
+                        listOf()
+                    }
+                }
             }
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/ScriptTree.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/ScriptTree.kt
@@ -62,28 +62,20 @@ public sealed class ScriptTree {
      * Callers may need to drop that element in some cases.
      */
     public fun merkleProof(leafId: Int): List<ByteVector32> {
-        return when (this) {
-            is Leaf -> when (this.id) {
+        return when {
+            this is Leaf && this.id == leafId -> {
                 // We found our leaf: we can now walk up the tree to build the rest of the proof.
-                leafId -> listOf(this.hash())
-                // We reached a leaf that doesn't match our target: we're not on the right path.
-                else -> listOf()
+                listOf(this.hash())
             }
-            is Branch -> {
-                val leftProof = this.left.merkleProof(leafId)
-                if (leftProof.isNotEmpty()) {
-                    // Our target leaf is in that subtree: we add its sibling to the proof.
-                    leftProof + this.right.hash()
-                } else {
-                    val rightProof = this.right.merkleProof(leafId)
-                    if (rightProof.isNotEmpty()) {
-                        // Our target leaf is in that subtree: we add its sibling to the proof.
-                        rightProof + this.left.hash()
-                    } else {
-                        listOf()
-                    }
-                }
+            this is Branch && this.left.merkleProof(leafId).isNotEmpty() -> {
+                // Our target leaf is in that subtree: we add its sibling to the proof.
+                this.left.merkleProof(leafId) + this.right.hash()
             }
+            this is Branch && this.right.merkleProof(leafId).isNotEmpty() -> {
+                // Our target leaf is in that subtree: we add its sibling to the proof.
+                this.right.merkleProof(leafId) + this.left.hash()
+            }
+            else -> listOf()
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/XonlyPublicKey.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/XonlyPublicKey.kt
@@ -34,11 +34,15 @@ public data class XonlyPublicKey(@JvmField val value: ByteVector32) {
     }
 
     /**
-     * "tweaks" this key with an optional merkle root
+     * Tweak this key with an optional merkle root.
+     *
      * @param tapTweak taproot tweak
      * @return an (x-only pubkey, parity) pair
      */
     public fun outputKey(tapTweak: Crypto.TaprootTweak): Pair<XonlyPublicKey, Boolean> = this + PrivateKey(tweak(tapTweak)).publicKey()
+
+    /** Tweak this key with the merkle root of the given script tree. */
+    public fun outputKey(scriptTree: ScriptTree): Pair<XonlyPublicKey, Boolean> = outputKey(Crypto.TaprootTweak.ScriptTweak(scriptTree))
 
     /**
      * add a public key to this x-only key

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/XonlyPublicKey.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/XonlyPublicKey.kt
@@ -44,6 +44,9 @@ public data class XonlyPublicKey(@JvmField val value: ByteVector32) {
     /** Tweak this key with the merkle root of the given script tree. */
     public fun outputKey(scriptTree: ScriptTree): Pair<XonlyPublicKey, Boolean> = outputKey(Crypto.TaprootTweak.ScriptTweak(scriptTree))
 
+    /** Tweak this key with the merkle root provided. */
+    public fun outputKey(merkleRoot: ByteVector32): Pair<XonlyPublicKey, Boolean> = outputKey(Crypto.TaprootTweak.ScriptTweak(merkleRoot))
+
     /**
      * add a public key to this x-only key
      * @param that public key

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/Musig2TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/Musig2TestsCommon.kt
@@ -79,7 +79,7 @@ class Musig2TestsCommon {
     }
 
     @Test
-    fun `sign`() {
+    fun sign() {
         val tests = TransactionTestsCommon.readData("musig2/sign_verify_vectors.json")
         val sk = PrivateKey.fromHex(tests.jsonObject["sk"]!!.jsonPrimitive.content)
         val pubkeys = tests.jsonObject["pubkeys"]!!.jsonArray.map { PublicKey(ByteVector(it.jsonPrimitive.content)) }
@@ -221,7 +221,7 @@ class Musig2TestsCommon {
 
     @Test
     fun `simple musig2 example`() {
-        val random = kotlin.random.Random.Default
+        val random = Random.Default
         val msg = random.nextBytes(32).byteVector32()
 
         val privkeys = listOf(
@@ -294,12 +294,12 @@ class Musig2TestsCommon {
         val spendingTx = Transaction(2, listOf(TxIn(OutPoint(tx, 0), sequence = 0)), listOf(TxOut(Satoshi(10000), Script.pay2wpkh(alicePubKey))), 0)
 
         val commonSig = run {
-            val random = kotlin.random.Random.Default
+            val random = Random.Default
             val aliceNonce = SecretNonce.generate(alicePrivKey, alicePubKey, commonPubKey, null, null, random.nextBytes(32).byteVector32())
             val bobNonce = SecretNonce.generate(bobPrivKey, bobPubKey, commonPubKey, null, null, random.nextBytes(32).byteVector32())
 
             val aggnonce = IndividualNonce.aggregate(listOf(aliceNonce.publicNonce(), bobNonce.publicNonce()))
-            val msg = Transaction.hashForSigningSchnorr(spendingTx, 0, listOf(tx.txOut[0]), SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPROOT)
+            val msg = Transaction.hashForSigningTaprootKeyPath(spendingTx, 0, listOf(tx.txOut[0]), SigHash.SIGHASH_DEFAULT)
 
             // we use the same ctx for Alice and Bob, they both know all the public keys that are used here
             val ctx = SessionCtx(
@@ -325,20 +325,16 @@ class Musig2TestsCommon {
         val userRefundPrivateKey = PrivateKey(ByteArray(32) { 3 })
         val refundDelay = 25920
 
-        val random = Random
+        val random = Random.Default
 
         // the redeem script is just the refund script. it is generated from this policy: and_v(v:pk(user),older(refundDelay))
         // it does not depend upon the user's or server's key, just the user's refund key and the refund delay
         val redeemScript = listOf(OP_PUSHDATA(userRefundPrivateKey.publicKey().xOnly()), OP_CHECKSIGVERIFY, OP_PUSHDATA(Script.encodeNumber(refundDelay)), OP_CHECKSEQUENCEVERIFY)
         val scriptTree = ScriptTree.Leaf(0, redeemScript)
-        val merkleRoot = scriptTree.hash()
 
         // the internal pubkey is the musig2 aggregation of the user's and server's public keys: it does not depend upon the user's refund's key
         val internalPubKey = Musig2.keyAgg(listOf(userPrivateKey.publicKey(), serverPrivateKey.publicKey())).Q.xOnly()
-
-        // it is tweaked with the script's merkle root to get the pubkey that will be exposed
-        val (commonPubKey, _) = internalPubKey.outputKey(Crypto.TaprootTweak.ScriptTweak(merkleRoot))
-        val pubkeyScript: List<ScriptElt> = Script.pay2tr(commonPubKey)
+        val pubkeyScript = Script.pay2tr(internalPubKey, scriptTree)
 
         val swapInTx = Transaction(
             version = 2,
@@ -360,37 +356,33 @@ class Musig2TestsCommon {
             val userNonce = SecretNonce.generate(userPrivateKey, userPrivateKey.publicKey(), internalPubKey, null, null, random.nextBytes(32).byteVector32())
             val serverNonce = SecretNonce.generate(serverPrivateKey, serverPrivateKey.publicKey(), internalPubKey, null, null, random.nextBytes(32).byteVector32())
 
-            val txHash = Transaction.hashForSigningSchnorr(tx, 0, swapInTx.txOut, SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPROOT)
+            val txHash = Transaction.hashForSigningTaprootKeyPath(tx, 0, swapInTx.txOut, SigHash.SIGHASH_DEFAULT)
             val commonNonce = IndividualNonce.aggregate(listOf(userNonce.publicNonce(), serverNonce.publicNonce()))
             val ctx = SessionCtx(
                 commonNonce,
                 listOf(userPrivateKey.publicKey(), serverPrivateKey.publicKey()),
-                listOf(Pair(internalPubKey.tweak(Crypto.TaprootTweak.ScriptTweak(merkleRoot)), true)),
+                listOf(Pair(internalPubKey.tweak(Crypto.TaprootTweak.ScriptTweak(scriptTree)), true)),
                 txHash
             )
 
             val userSig = ctx.sign(userNonce, userPrivateKey)!!
             val serverSig = ctx.sign(serverNonce, serverPrivateKey)!!
             val commonSig = ctx.partialSigAgg(listOf(userSig, serverSig))!!
-            val signedTx = tx.updateWitness(0, ScriptWitness(listOf(commonSig)))
+            val signedTx = tx.updateWitness(0, Script.witnessKeyPathPay2tr(commonSig))
             Transaction.correctlySpends(signedTx, swapInTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
         }
 
         // Or it can be spent with only the user's signature, after a delay.
         run {
-            val executionData = Script.ExecutionData(annex = null, tapleafHash = merkleRoot)
-            val controlBlock = Script.ControlBlock.build(internalPubKey, scriptTree, scriptTree)
-
             val tx = Transaction(
                 version = 2,
                 txIn = listOf(TxIn(OutPoint(swapInTx, 0), sequence = refundDelay.toLong())),
                 txOut = listOf(TxOut(Satoshi(10000), Script.pay2wpkh(userPrivateKey.publicKey()))),
                 lockTime = 0
             )
-            val txHash = Transaction.hashForSigningSchnorr(tx, 0, swapInTx.txOut, SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPSCRIPT, executionData)
-
-            val sig = Crypto.signSchnorr(txHash, userRefundPrivateKey, Crypto.SchnorrTweak.NoTweak)
-            val signedTx = tx.updateWitness(0, ScriptWitness.empty.push(sig).push(redeemScript).push(controlBlock))
+            val sig = Crypto.signTaprootScriptPath(userRefundPrivateKey, tx, 0, swapInTx.txOut, SigHash.SIGHASH_DEFAULT, scriptTree.hash())
+            val witness = Script.witnessScriptPathPay2tr(internalPubKey, scriptTree, ScriptWitness(listOf(sig)), scriptTree)
+            val signedTx = tx.updateWitness(0, witness)
             Transaction.correctlySpends(signedTx, swapInTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/Musig2TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/Musig2TestsCommon.kt
@@ -330,8 +330,8 @@ class Musig2TestsCommon {
         // the redeem script is just the refund script. it is generated from this policy: and_v(v:pk(user),older(refundDelay))
         // it does not depend upon the user's or server's key, just the user's refund key and the refund delay
         val redeemScript = listOf(OP_PUSHDATA(userRefundPrivateKey.publicKey().xOnly()), OP_CHECKSIGVERIFY, OP_PUSHDATA(Script.encodeNumber(refundDelay)), OP_CHECKSEQUENCEVERIFY)
-        val scriptTree = ScriptTree.Leaf(ScriptLeaf(0, redeemScript, Script.TAPROOT_LEAF_TAPSCRIPT))
-        val merkleRoot = ScriptTree.hash(scriptTree)
+        val scriptTree = ScriptTree.Leaf(0, redeemScript)
+        val merkleRoot = scriptTree.hash()
 
         // the internal pubkey is the musig2 aggregation of the user's and server's public keys: it does not depend upon the user's refund's key
         val internalPubKey = Musig2.keyAgg(listOf(userPrivateKey.publicKey(), serverPrivateKey.publicKey())).Q.xOnly()
@@ -379,7 +379,7 @@ class Musig2TestsCommon {
         // Or it can be spent with only the user's signature, after a delay.
         run {
             val executionData = Script.ExecutionData(annex = null, tapleafHash = merkleRoot)
-            val controlBlock = Script.ControlBlock.build(internalPubKey, merkleRoot)
+            val controlBlock = Script.ControlBlock.build(internalPubKey, scriptTree, scriptTree)
 
             val tx = Transaction(
                 version = 2,

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
@@ -31,15 +31,18 @@ class TaprootTestsCommon {
         // derive BIP86 wallet key
         val (_, master) = DeterministicWallet.ExtendedPrivateKey.decode("tprv8ZgxMBicQKsPeQQADibg4WF7mEasy3piWZUHyThAzJCPNgMHDVYhTCVfev3jFbDhcYm4GimeFMbbi9z1d9rfY1aL5wfJ9mNebQ4thJ62EJb")
         val key = DeterministicWallet.derivePrivateKey(master, "86'/1'/0'/0/1")
-        val internalKey = XonlyPublicKey(key.publicKey)
+        val internalKey = key.publicKey.xOnly()
+        val script = Script.pay2tr(internalKey, scripts = null)
         val outputKey = internalKey.outputKey(Crypto.TaprootTweak.NoScriptTweak).first
         assertEquals("tb1phlhs7afhqzkgv0n537xs939s687826vn8l24ldkrckvwsnlj3d7qj6u57c", Bech32.encodeWitnessAddress("tb", 1, outputKey.value.toByteArray()))
+        assertEquals(script, Script.pay2tr(outputKey))
 
         // tx sends to tb1phlhs7afhqzkgv0n537xs939s687826vn8l24ldkrckvwsnlj3d7qj6u57c
         val tx = Transaction.read(
             "02000000000101590c995983abb86d8196f57357f2aac0e6cc6144d8239fd8a171810b476269d50000000000feffffff02a086010000000000225120bfef0f753700ac863e748f8d02c4b0d1fc7569933fd55fb6c3c598e84ff28b7c13d3abe65a060000160014353b5487959c58f5feafe63800057899f9ece4280247304402200b20c43175358c970850a583fd60d36c06588f1103b82b0968dc21e20e7d7958022027c64923623205c4985541d4a9fc6b5df4111d918fe63803337538b029c17ea20121022f685476d299e7b49d3a6b380e10aec1f93d96819fd7697669fabb533cc052624ff50000"
         )
-        assertEquals(Script.pay2tr(outputKey), Script.parse(tx.txOut[0].publicKeyScript))
+        assertTrue(Script.isPay2tr(tx.txOut[0].publicKeyScript))
+        assertEquals(script, Script.parse(tx.txOut[0].publicKeyScript))
 
         // tx1 spends tx using key path spending i.e its witness just includes a single signature that is valid for outputKey
         val tx1 = Transaction.read(
@@ -72,7 +75,7 @@ class TaprootTestsCommon {
     @Test
     fun `send to and spend from taproot addresses`() {
         val privateKey = PrivateKey(ByteVector32("0101010101010101010101010101010101010101010101010101010101010101"))
-        val internalKey = XonlyPublicKey(privateKey.publicKey())
+        val internalKey = privateKey.publicKey().xOnly()
         val outputKey = internalKey.outputKey(Crypto.TaprootTweak.NoScriptTweak).first
         val address = Bech32.encodeWitnessAddress("tb", 1, outputKey.value.toByteArray())
         assertEquals("tb1p33wm0auhr9kkahzd6l0kqj85af4cswn276hsxg6zpz85xe2r0y8snwrkwy", address)
@@ -81,7 +84,7 @@ class TaprootTestsCommon {
         val tx = Transaction.read(
             "02000000000101bf77ef36f2c0f32e0822cef0514948254997495a34bfba7dd4a73aabfcbb87900000000000fdffffff02c2c2000000000000160014b5c3dbfeb8e7d0c809c3ba3f815fd430777ef4be50c30000000000002251208c5db7f797196d6edc4dd7df6048f4ea6b883a6af6af032342088f436543790f0140583f758bea307216e03c1f54c3c6088e8923c8e1c89d96679fb00de9e808a79d0fba1cc3f9521cb686e8f43fb37cc6429f2e1480c70cc25ecb4ac0dde8921a01f1f70000"
         )
-        assertEquals(Script.pay2tr(outputKey), Script.parse(tx.txOut[1].publicKeyScript))
+        assertEquals(Script.pay2tr(internalKey, scripts = null), Script.parse(tx.txOut[1].publicKeyScript))
 
         // we want to spend
         val outputScript = addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, "tb1pn3g330w4n5eut7d4vxq0pp303267qc6vg8d2e0ctjuqre06gs3yqnc5yx0").result!!
@@ -92,9 +95,8 @@ class TaprootTestsCommon {
             0
         )
         val sigHashType = 0
-        val hash = hashForSigningSchnorr(tx1, 0, listOf(tx.txOut[1]), sigHashType, 0)
-        val sig = Crypto.signSchnorr(hash, privateKey, Crypto.TaprootTweak.NoScriptTweak)
-        val tx2 = tx1.updateWitness(0, ScriptWitness(listOf(sig)))
+        val sig = Crypto.signTaprootKeyPath(privateKey, tx1, 0, listOf(tx.txOut[1]), sigHashType, scriptTree = null)
+        val tx2 = tx1.updateWitness(0, Script.witnessKeyPathPay2tr(sig))
         Transaction.correctlySpends(tx2, tx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     }
 
@@ -176,13 +178,11 @@ class TaprootTestsCommon {
 
         // simple script tree with a single element
         val scriptTree = ScriptTree.Leaf(0, script)
-        val merkleRoot = scriptTree.hash()
         // we choose a pubkey that does not have a corresponding private key: our funding tx can only be spent through the script path, not the key path
-        val internalPubkey = XonlyPublicKey(PublicKey.fromHex("0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"))
-        val (tweakedKey, _) = internalPubkey.outputKey(Crypto.TaprootTweak.ScriptTweak(merkleRoot))
+        val internalPubkey = PublicKey.fromHex("0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0").xOnly()
 
         // funding tx sends to our tapscript
-        val fundingTx = Transaction(version = 2, txIn = listOf(), txOut = listOf(TxOut(Satoshi(1000000), listOf(OP_1, OP_PUSHDATA(tweakedKey)))), lockTime = 0)
+        val fundingTx = Transaction(version = 2, txIn = listOf(), txOut = listOf(TxOut(Satoshi(1000000), Script.pay2tr(internalPubkey, scriptTree))), lockTime = 0)
 
         // create an unsigned transaction
         val tmp = Transaction(
@@ -191,30 +191,26 @@ class TaprootTestsCommon {
             txOut = listOf(TxOut(fundingTx.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, "bcrt1qdtu5cwyngza8hw8s5uk2erlrkh8ceh3msp768v").result!!)),
             lockTime = 0
         )
-        val hash = hashForSigningSchnorr(tmp, 0, listOf(fundingTx.txOut[0]), SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPSCRIPT, Script.ExecutionData(annex = null, tapleafHash = merkleRoot))
 
         // compute all 3 signatures
-        val sigs = privs.map { Crypto.signSchnorr(hash, it, Crypto.SchnorrTweak.NoTweak) }
-
-        // The control is the same for everyone since the script tree contains a single script.
-        val controlBlock = Script.ControlBlock.build(internalPubkey, scriptTree, scriptTree)
+        val sigs = privs.map { Crypto.signTaprootScriptPath(it, tmp, 0, listOf(fundingTx.txOut[0]), SigHash.SIGHASH_DEFAULT, scriptTree.hash()) }
 
         // one signature is not enough
-        val tx = tmp.updateWitness(0, ScriptWitness(listOf(sigs[0], sigs[0], sigs[0], Script.write(script).byteVector(), controlBlock)))
+        val tx = tmp.updateWitness(0, Script.witnessScriptPathPay2tr(internalPubkey, scriptTree, ScriptWitness(listOf(sigs[0], sigs[0], sigs[0])), scriptTree))
         assertFails {
             Transaction.correctlySpends(tx, fundingTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
         }
 
         // spend with sigs #0 and #1
-        val tx1 = tmp.updateWitness(0, ScriptWitness(listOf(ByteVector.empty, sigs[1], sigs[0], Script.write(script).byteVector(), controlBlock)))
+        val tx1 = tmp.updateWitness(0, Script.witnessScriptPathPay2tr(internalPubkey, scriptTree, ScriptWitness(listOf(ByteVector.empty, sigs[1], sigs[0])), scriptTree))
         Transaction.correctlySpends(tx1, fundingTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
         // spend with sigs #1 and #2
-        val tx2 = tmp.updateWitness(0, ScriptWitness(listOf(sigs[2], ByteVector.empty, sigs[0], Script.write(script).byteVector(), controlBlock)))
+        val tx2 = tmp.updateWitness(0, Script.witnessScriptPathPay2tr(internalPubkey, scriptTree, ScriptWitness(listOf(sigs[2], ByteVector.empty, sigs[0])), scriptTree))
         Transaction.correctlySpends(tx2, fundingTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
         // spend with sigs #0, #1 and #2
-        val tx3 = tmp.updateWitness(0, ScriptWitness(listOf(sigs[2], sigs[1], sigs[0], Script.write(script).byteVector(), controlBlock)))
+        val tx3 = tmp.updateWitness(0, Script.witnessScriptPathPay2tr(internalPubkey, scriptTree, ScriptWitness(listOf(sigs[2], sigs[1], sigs[0])), scriptTree))
         Transaction.correctlySpends(tx3, fundingTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     }
 
@@ -226,7 +222,7 @@ class TaprootTestsCommon {
             PrivateKey(ByteVector32("0101010101010101010101010101010101010101010101010101010101010102")),
             PrivateKey(ByteVector32("0101010101010101010101010101010101010101010101010101010101010103"))
         )
-        val scripts = privs.map { listOf(OP_PUSHDATA(XonlyPublicKey(it.publicKey()).value), OP_CHECKSIG) }
+        val scripts = privs.map { listOf(OP_PUSHDATA(it.publicKey().xOnly().value), OP_CHECKSIG) }
         val leaves = scripts.mapIndexed { idx, script -> ScriptTree.Leaf(idx, script) }
         //     root
         //    /   \
@@ -236,15 +232,14 @@ class TaprootTestsCommon {
             ScriptTree.Branch(leaves[0], leaves[1]),
             leaves[2]
         )
-        val merkleRoot = scriptTree.hash()
         val blockchain = Block.SignetGenesisBlock.hash
 
         // we use key #1 as our internal key
-        val internalPubkey = XonlyPublicKey(privs[0].publicKey())
-        val (tweakedKey, _) = internalPubkey.outputKey(Crypto.TaprootTweak.ScriptTweak(merkleRoot))
+        val internalPubkey = privs[0].publicKey().xOnly()
+        val (tweakedKey, _) = internalPubkey.outputKey(scriptTree)
 
         // this is the tapscript we send funds to
-        val script = Script.write(listOf(OP_1, OP_PUSHDATA(tweakedKey.value))).byteVector()
+        val script = Script.pay2tr(internalPubkey, scriptTree)
         val bip350Address = Bech32.encodeWitnessAddress(hrp(blockchain), 1.toByte(), tweakedKey.value.toByteArray())
         assertEquals(bip350Address, "tb1p78gx95syx0qz8w5nftk8t7nce78zlpqpsxugcvq5xpfy4tvn6rasd7wk0y")
         val sweepPublicKeyScript = addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").result!!
@@ -255,8 +250,8 @@ class TaprootTestsCommon {
         )
 
         // output #1 is the one we want to spend
-        assertEquals(fundingTx.txOut[0].publicKeyScript, script)
-        assertEquals(addressToPublicKeyScript(blockchain, bip350Address).result, listOf(OP_1, OP_PUSHDATA(tweakedKey.value)))
+        assertEquals(fundingTx.txOut[0].publicKeyScript, Script.write(script).byteVector())
+        assertEquals(addressToPublicKeyScript(blockchain, bip350Address).result, script)
 
         // spending with the key path: no need to provide any script
         val tx = run {
@@ -266,10 +261,9 @@ class TaprootTestsCommon {
                 txOut = listOf(TxOut(fundingTx.txOut[0].amount - Satoshi(5000), sweepPublicKeyScript)),
                 lockTime = 0
             )
-            val hash = hashForSigningSchnorr(tmp, 0, listOf(fundingTx.txOut[0]), SigHash.SIGHASH_DEFAULT, 0)
-            // we still need to know the merkle root of the tapscript tree
-            val sig = Crypto.signSchnorr(hash, privs[0], Crypto.TaprootTweak.ScriptTweak(merkleRoot))
-            tmp.updateWitness(0, ScriptWitness(listOf(sig)))
+            // We still need to provide the tapscript tree because it is used to tweak the private key.
+            val sig = Crypto.signTaprootKeyPath(privs[0], tmp, 0, listOf(fundingTx.txOut[0]), SigHash.SIGHASH_DEFAULT, scriptTree)
+            tmp.updateWitness(0, Script.witnessKeyPathPay2tr(sig))
         }
 
         // see: https://mempool.space/signet/tx/de3e4dcf07e68c7b237269eee75b926b9d147869f6317031b0550dcbf509ff5b
@@ -283,7 +277,7 @@ class TaprootTestsCommon {
         val fundingTx1 = Transaction.read(
             "020000000001032c94e663cbee0edbdb4375bb2e79be60f8ecfa4e936a14e9a054b1c8923928570000000000feffffff308788df38f369e33bcd70765c171a9796d910b02525a550bfe4d2a2cf8a710c0100000000feffffff94dc10cd523655b0323e90428d720b378b91de312e56908325df6878c530d30d0000000000feffffff0200e1f50500000000225120f1d062d20433c023ba934aec75fa78cf8e2f840181b88c301430524aad93d0fb8b4f174e020000001600140e361914cb87862fb6ea24193331d6591b59859002463043021f5dcc64a2fef28bdd2b88b5d10851079cc98663a1284d0569bdde5afc558fb202205c2bcdcf1dae62b2c32e8cf6ac6cb2534b70b1889be893da170564a8c4d40f2001210270b71142cd209ddd686ef013adaeb12b641fde95d589a5a607ee0b6c95cc086202473044022034121d55d61376aee90f6b975522b6bad85491448d527b83f6dacbdddcd9548202201a0a9405542ae06239fabdc01069fe2518ee7340ed400d4db2d92604f9d454d601210319b3ad1b37d95ab41034cd810799149501e62ab6d009a6a4eca6034f78ca725b024730440220487663d7740eaa5370673f4807497970feb2d69c83cae281d89fef8aa616259a02200a21dc493e455c2980bc245224eb67aba576f732f77af0fd555a5f44fa205e4d0121023a34e31279a234431b349fd229790038c95c837a8139862df9cbb1226d63c4003eb10100"
         )
-        assertEquals(fundingTx1.txOut[0].publicKeyScript, script)
+        assertEquals(fundingTx1.txOut[0].publicKeyScript, Script.write(script).byteVector())
 
         // spending with script #1
         val tx1 = run {
@@ -293,10 +287,9 @@ class TaprootTestsCommon {
                 txOut = listOf(TxOut(fundingTx1.txOut[0].amount - Satoshi(5000), sweepPublicKeyScript)),
                 lockTime = 0
             )
-            val controlBlock = Script.ControlBlock.build(internalPubkey, scriptTree, leaves[0])
-            val hash = hashForSigningSchnorr(tmp, 0, listOf(fundingTx.txOut[0]), SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPSCRIPT, Script.ExecutionData(null, leaves[0].hash()))
-            val sig = Crypto.signSchnorr(hash, privs[0], Crypto.SchnorrTweak.NoTweak)
-            tmp.updateWitness(0, ScriptWitness(listOf(sig, Script.write(scripts[0]).byteVector(), controlBlock)))
+            val sig = Crypto.signTaprootScriptPath(privs[0], tmp, 0, listOf(fundingTx.txOut[0]), SigHash.SIGHASH_DEFAULT, leaves[0].hash())
+            val witness = Script.witnessScriptPathPay2tr(internalPubkey, leaves[0], ScriptWitness(listOf(sig)), scriptTree)
+            tmp.updateWitness(0, witness)
         }
 
         // see: https://mempool.space/signet/tx/5586515f9ed7fce8b7e8be97a8681c298a94166ff95e15edd94226edec50d9ea
@@ -310,7 +303,7 @@ class TaprootTestsCommon {
         val fundingTx2 = Transaction.read(
             "02000000000101c1952516d2f512e8ec29ffe576fcb13903987434ce22479f2e18b5060f0184c20100000000feffffff0200e1f50500000000225120f1d062d20433c023ba934aec75fa78cf8e2f840181b88c301430524aad93d0fb28b1b61100000000160014665ea2d5f8f03b7edc82472baed5ba28dcd22a9f024730440220014381ea4fc0e96733231b84bf9d24ee6d197147c2d2842c896530103c9c23310220384d174f4578767f2117c558671e592ea497f0680cedbacc73dc3f4c316f6b73012102d2212f3a1ef1a797be1fbe8ac784eb81158957339cab89e32faa6f73cc9bf6713fb10100"
         )
-        assertEquals(fundingTx2.txOut[0].publicKeyScript, script)
+        assertEquals(fundingTx2.txOut[0].publicKeyScript, Script.write(script).byteVector())
 
         // spending with script #2
         // it's basically the same as for key #1
@@ -321,10 +314,9 @@ class TaprootTestsCommon {
                 txOut = listOf(TxOut(fundingTx2.txOut[0].amount - Satoshi(5000), sweepPublicKeyScript)),
                 lockTime = 0
             )
-            val controlBlock = Script.ControlBlock.build(internalPubkey, scriptTree, leaves[1])
-            val hash = hashForSigningSchnorr(tmp, 0, listOf(fundingTx2.txOut[0]), SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPSCRIPT, Script.ExecutionData(null, leaves[1].hash()))
-            val sig = Crypto.signSchnorr(hash, privs[1], Crypto.SchnorrTweak.NoTweak) // signature for script spend of leaf #2
-            tmp.updateWitness(0, ScriptWitness(listOf(sig, Script.write(scripts[1]).byteVector(), controlBlock)))
+            val sig = Crypto.signTaprootScriptPath(privs[1], tmp, 0, listOf(fundingTx2.txOut[0]), SigHash.SIGHASH_DEFAULT, leaves[1].hash())
+            val witness = Script.witnessScriptPathPay2tr(internalPubkey, leaves[1], ScriptWitness(listOf(sig)), scriptTree)
+            tmp.updateWitness(0, witness)
         }
 
         // see: https://mempool.space/signet/tx/5586515f9ed7fce8b7e8be97a8681c298a94166ff95e15edd94226edec50d9ea
@@ -338,7 +330,7 @@ class TaprootTestsCommon {
         val fundingTx3 = Transaction.read(
             "020000000001025bff09f5cb0d55b0317031f66978149d6b925be7ee6972237b8ce607cf4d3ede0000000000feffffffead950eced2642d9ed155ef96f16948a291c68a897bee8b7e8fcd79e5f5186550000000000feffffff0214b9f50500000000160014faf51bb67e3e35a93aa549cf2c8d24763d8162ce00e1f50500000000225120f1d062d20433c023ba934aec75fa78cf8e2f840181b88c301430524aad93d0fb0247304402201989eb9d1f4d976a9f0bf512e7f1fa784c45eee369a6c13511162a463c89935002201a1d41e53c56600137a851d0c26daaffd6aa30197fbf9221daf6cbca458fb40f012102238ee9a8b833398e3421c809e7ac75089e4e738841577273fe87d3cd14a22cf202473044022035e887ced3bb03f54cce39e4cdecf93b787765c51de2545a16c97fec67d3085b02200bd15d5497d1a9be37ad29142673ef2cdc0cee69f6a9cf5643c376a4b4f81489012102238ee9a8b833398e3421c809e7ac75089e4e738841577273fe87d3cd14a22cf290b10100"
         )
-        assertEquals(fundingTx3.txOut[1].publicKeyScript, script)
+        assertEquals(fundingTx3.txOut[1].publicKeyScript, Script.write(script).byteVector())
 
         // spending with script #3
         val tx3 = run {
@@ -348,10 +340,9 @@ class TaprootTestsCommon {
                 txOut = listOf(TxOut(fundingTx3.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").result!!)),
                 lockTime = 0
             )
-            val controlBlock = Script.ControlBlock.build(internalPubkey, scriptTree, leaves[2])
-            val hash = hashForSigningSchnorr(tmp, 0, listOf(fundingTx3.txOut[1]), SigHash.SIGHASH_DEFAULT, SigVersion.SIGVERSION_TAPSCRIPT, Script.ExecutionData(null, leaves[2].hash()))
-            val sig = Crypto.signSchnorr(hash, privs[2], Crypto.SchnorrTweak.NoTweak) // signature for script spend of leaf #3
-            tmp.updateWitness(0, ScriptWitness(listOf(sig, Script.write(scripts[2]).byteVector(), controlBlock)))
+            val sig = Crypto.signTaprootScriptPath(privs[2], tmp, 0, listOf(fundingTx3.txOut[1]), SigHash.SIGHASH_DEFAULT, leaves[2].hash())
+            val witness = Script.witnessScriptPathPay2tr(internalPubkey, leaves[2], ScriptWitness(listOf(sig)), scriptTree)
+            tmp.updateWitness(0, witness)
         }
 
         // see: https://mempool.space/signet/tx/2eb421e044de0535aa3d14a5a4c325ba8b5181440bbd911b5b43718b686b09a8

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/reference/BIP341TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/reference/BIP341TestsCommon.kt
@@ -20,6 +20,7 @@ import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.json.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class BIP341TestsCommon {
     @Test
@@ -43,7 +44,7 @@ class BIP341TestsCommon {
             assertEquals(hashScriptPubkeys, Hex.encode(Transaction.scriptPubkeysSha256(utxosSpent)))
             assertEquals(hashSequences, Hex.encode(Transaction.sequencesSha256(rawUnsignedTx)))
 
-            val previousOutputs = (fullySignedTx.txIn.map {it.outPoint}).zip(utxosSpent).toMap()
+            val previousOutputs = (fullySignedTx.txIn.map { it.outPoint }).zip(utxosSpent).toMap()
             Transaction.correctlySpends(fullySignedTx, previousOutputs, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
             it.jsonObject["inputSpending"]!!.jsonArray.forEach {
@@ -86,12 +87,12 @@ class BIP341TestsCommon {
             val internalPubkey = XonlyPublicKey(ByteVector32.fromValidHex(given["internalPubkey"]!!.jsonPrimitive.content))
             val scriptTree = when (val json = it.jsonObject["given"]!!.jsonObject["scriptTree"]) {
                 null, JsonNull -> null
-                else -> read(json) { fromJson(it) }
+                else -> scriptTreeFromJson(json)
             }
 
             val intermediary = it.jsonObject["intermediary"]!!.jsonObject
-            val merkleRoot = scriptTree?.let { ScriptTree.hash(it) }
-            val (tweakedKey, parity) = internalPubkey.outputKey(if (merkleRoot == null) Crypto.TaprootTweak.NoScriptTweak else Crypto.TaprootTweak.ScriptTweak(merkleRoot))
+            val merkleRoot = scriptTree?.hash()
+            val (tweakedKey, _) = internalPubkey.outputKey(if (merkleRoot == null) Crypto.TaprootTweak.NoScriptTweak else Crypto.TaprootTweak.ScriptTweak(merkleRoot))
             merkleRoot?.let { assertEquals(ByteVector32(intermediary["merkleRoot"]!!.jsonPrimitive.content), it) }
             assertEquals(ByteVector32(intermediary["tweakedPubkey"]!!.jsonPrimitive.content), tweakedKey.value)
 
@@ -104,53 +105,39 @@ class BIP341TestsCommon {
             when (expected["scriptPathControlBlocks"]) {
                 null, JsonNull -> Unit
                 else -> {
-                    // when control blocks are provided, recompute them for each script tree leaf and check that they match
+                    // When control blocks are provided, recompute them for each script tree leaf and check that they match.
+                    assertNotNull(scriptTree)
                     val controlBlocks = expected["scriptPathControlBlocks"]!!.jsonArray.map { ByteVector.fromHex(it.jsonPrimitive.content) }
-                    val paths = mutableListOf<Pair<Int, ByteArray>>()
-                    merklePath(scriptTree!!) { leafVersion, hashes -> paths.add(Pair(leafVersion, hashes)) }
-                    val computed = paths.map {
-                        // for each leaf in the script tree the control block is:
-                        // leaf version + parity (1 byte) || internal pub key (32 bytes) || merkle path for this leaf (N * 32 bytes)
-                        (byteArrayOf((if (parity) it.first + 1 else it.first).toByte()) + internalPubkey.value.toByteArray() + it.second).byteVector()
+                    controlBlocks.forEachIndexed { index, expectedControlBlock ->
+                        val scriptLeaf = scriptTree.findScript(index)
+                        assertNotNull(scriptLeaf)
+                        val computedControlBlock = Script.ControlBlock.build(internalPubkey, scriptTree, scriptLeaf)
+                        assertEquals(expectedControlBlock, computedControlBlock)
                     }
-                    assertEquals(controlBlocks, computed)
                 }
             }
         }
     }
 
-    private fun nullOrBytes(input: String?): ByteVector32? = when (input) {
-        null, "null" -> null
-        else -> ByteVector32(input)
-    }
-
     companion object {
-        fun fromJson(json: JsonElement): ScriptLeaf = ScriptLeaf(
+        private fun nullOrBytes(input: String?): ByteVector32? = when (input) {
+            null, "null" -> null
+            else -> ByteVector32(input)
+        }
+
+        private fun scriptLeafFromJson(json: JsonElement): ScriptTree.Leaf = ScriptTree.Leaf(
             id = json.jsonObject["id"]!!.jsonPrimitive.int,
             script = ByteVector.fromHex(json.jsonObject["script"]!!.jsonPrimitive.content),
             leafVersion = json.jsonObject["leafVersion"]!!.jsonPrimitive.int
         )
 
-        fun <T> read(json: JsonElement, f: (JsonElement) -> T): ScriptTree<T> = when (json) {
-            is JsonObject -> ScriptTree.Leaf(f(json))
-            is JsonArray -> ScriptTree.Branch(read(json[0], f), read(json[1], f))
-            else -> error("unexpected $json")
-        }
-
-        /**
-         * computes the merkle paths for each leaf in the merkle tree.
-         *
-         * the input tree is traversed down and each time we reach a leaf. `onLeaf` will be call with the leaf version and the merkle path for this leaf (i.e. the concatenated
-         * list of hashes you have to provide to recompute the tree hash from this leaf)
-         */
-        fun merklePath(tree: ScriptTree<ScriptLeaf>, hashes: ByteArray = byteArrayOf(), onLeaf: (Int, ByteArray) -> Unit) {
-            when (tree) {
-                is ScriptTree.Leaf -> onLeaf(tree.value.leafVersion, hashes)
-                is ScriptTree.Branch -> {
-                    merklePath(tree.left, ScriptTree.hash(tree.right).toByteArray() + hashes, onLeaf)
-                    merklePath(tree.right, ScriptTree.hash(tree.left).toByteArray() + hashes, onLeaf)
-                }
+        fun scriptTreeFromJson(json: JsonElement): ScriptTree = when (json) {
+            is JsonObject -> scriptLeafFromJson(json)
+            is JsonArray -> {
+                require(json.size == 2) { "script tree must contain exactly two branches: $json" }
+                ScriptTree.Branch(scriptTreeFromJson(json[0]), scriptTreeFromJson(json[1]))
             }
+            else -> error("unexpected $json")
         }
     }
 }


### PR DESCRIPTION
Returning a single nullable byte array  feels cleaner (and internally this is how such proof are used), remove the ambiguity of returning an empty list, and the need to remove the last element.