### PR TITLE
Use Either for error handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 group = "fr.acinq.bitcoin"
-version = "0.17.0-EITHER-SNAPSHOT"
+version = "0.17.0-SNAPSHOT"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 group = "fr.acinq.bitcoin"
-version = "0.17.0-SNAPSHOT"
+version = "0.17.0-EITHER-SNAPSHOT"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Bitcoin.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Bitcoin.kt
@@ -16,6 +16,7 @@
 
 package fr.acinq.bitcoin
 
+import fr.acinq.bitcoin.utils.Either
 import kotlin.jvm.JvmStatic
 
 public const val MaxBlockSize: Int = 1000000
@@ -26,63 +27,14 @@ public fun <T> List<T>.updated(i: Int, t: T): List<T> = when (i) {
     else -> this.take(i) + t + this.drop(i + 1)
 }
 
-public sealed class AddressToPublicKeyScriptResult {
-
-    public abstract val result: List<ScriptElt>?
-
-    public fun isSuccess(): Boolean = result != null
-
-    public fun isFailure(): Boolean = !isSuccess()
-
-    public data class Success(val script: List<ScriptElt>) : AddressToPublicKeyScriptResult() {
-        override val result: List<ScriptElt> = script
-    }
-
-    public sealed class Failure : AddressToPublicKeyScriptResult() {
-        override val result: List<ScriptElt>? = null
-
-        public object ChainHashMismatch : Failure() {
-            override fun toString(): String = "chain hash mismatch"
-        }
-
-        public object InvalidAddress : Failure() {
-            override fun toString(): String = "invalid base58 or bech32 address "
-        }
-
-        public object InvalidBech32Address : Failure() {
-            override fun toString(): String = "invalid bech32 address"
-        }
-
-        public data class InvalidWitnessVersion(val version: Int) : Failure() {
-            override fun toString(): String = "invalid witness version $version"
-        }
-    }
-}
-
-public sealed class AddressFromPublicKeyScriptResult {
-    public abstract val result: String?
-    public fun isSuccess(): Boolean = result != null
-    public fun isFailure(): Boolean = !isSuccess()
-
-    public data class Success(val address: String) : AddressFromPublicKeyScriptResult() {
-        override val result: String = address
-    }
-
-    public sealed class Failure : AddressFromPublicKeyScriptResult() {
-        override val result: String? = null
-
-        public object InvalidChainHash : Failure() {
-            override fun toString(): String = "invalid chain hash"
-        }
-
-        public object InvalidScript : Failure() {
-            override fun toString(): String = "invalid script"
-        }
-
-        public data class GenericError(val t: Throwable) : Failure() {
-            override fun toString(): String = "generic failure: ${t.message}"
-        }
-    }
+public sealed class BitcoinException(message: String, cause: Throwable?) : Exception(message, cause) {
+    public data object InvalidChainHash : BitcoinException("invalid chain hash", null)
+    public data object ChainHashMismatch : BitcoinException("chain hash mismatch", null)
+    public data object InvalidScript : BitcoinException("invalid script", null)
+    public data object InvalidAddress : BitcoinException("invalid address", null)
+    public data object InvalidBech32Address : BitcoinException("invalid address", null)
+    public data class InvalidWitnessVersion(val version: Int) : BitcoinException("invalid witness version $version", null)
+    public data class GenericError(override val message: String, override val cause: Throwable?) : BitcoinException(message, cause)
 }
 
 public object Bitcoin {
@@ -121,25 +73,25 @@ public object Bitcoin {
      * @param pubkeyScript public key script
      */
     @JvmStatic
-    public fun addressFromPublicKeyScript(chainHash: BlockHash, pubkeyScript: List<ScriptElt>): AddressFromPublicKeyScriptResult {
+    public fun addressFromPublicKeyScript(chainHash: BlockHash, pubkeyScript: List<ScriptElt>): Either<BitcoinException, String> {
         try {
             return when {
                 Script.isPay2pkh(pubkeyScript) -> {
                     val prefix = when (chainHash) {
                         Block.LivenetGenesisBlock.hash -> Base58.Prefix.PubkeyAddress
                         Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Base58.Prefix.PubkeyAddressTestnet
-                        else -> return AddressFromPublicKeyScriptResult.Failure.InvalidChainHash
+                        else -> return Either.Left(BitcoinException.InvalidChainHash)
                     }
-                    AddressFromPublicKeyScriptResult.Success(Base58Check.encode(prefix, (pubkeyScript[2] as OP_PUSHDATA).data))
+                    Either.Right(Base58Check.encode(prefix, (pubkeyScript[2] as OP_PUSHDATA).data))
                 }
 
                 Script.isPay2sh(pubkeyScript) -> {
                     val prefix = when (chainHash) {
                         Block.LivenetGenesisBlock.hash -> Base58.Prefix.ScriptAddress
                         Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash, Block.SignetGenesisBlock.hash -> Base58.Prefix.ScriptAddressTestnet
-                        else -> return AddressFromPublicKeyScriptResult.Failure.InvalidChainHash
+                        else -> return Either.Left(BitcoinException.InvalidChainHash)
                     }
-                    AddressFromPublicKeyScriptResult.Success(Base58Check.encode(prefix, (pubkeyScript[1] as OP_PUSHDATA).data))
+                    Either.Right(Base58Check.encode(prefix, (pubkeyScript[1] as OP_PUSHDATA).data))
                 }
 
                 Script.isNativeWitnessScript(pubkeyScript) -> {
@@ -147,51 +99,51 @@ public object Bitcoin {
                     val witnessScript = (pubkeyScript[1] as OP_PUSHDATA).data.toByteArray()
                     when (pubkeyScript[0]) {
                         is OP_0 -> when {
-                            Script.isPay2wpkh(pubkeyScript) || Script.isPay2wsh(pubkeyScript) -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 0, witnessScript))
-                            else -> AddressFromPublicKeyScriptResult.Failure.InvalidScript
+                            Script.isPay2wpkh(pubkeyScript) || Script.isPay2wsh(pubkeyScript) -> Either.Right(Bech32.encodeWitnessAddress(hrp, 0, witnessScript))
+                            else -> return Either.Left(BitcoinException.InvalidScript)
                         }
 
-                        is OP_1 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 1, witnessScript))
-                        is OP_2 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 2, witnessScript))
-                        is OP_3 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 3, witnessScript))
-                        is OP_4 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 4, witnessScript))
-                        is OP_5 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 5, witnessScript))
-                        is OP_6 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 6, witnessScript))
-                        is OP_7 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 7, witnessScript))
-                        is OP_8 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 8, witnessScript))
-                        is OP_9 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 9, witnessScript))
-                        is OP_10 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 10, witnessScript))
-                        is OP_11 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 11, witnessScript))
-                        is OP_12 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 12, witnessScript))
-                        is OP_13 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 13, witnessScript))
-                        is OP_14 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 14, witnessScript))
-                        is OP_15 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 15, witnessScript))
-                        is OP_16 -> AddressFromPublicKeyScriptResult.Success(Bech32.encodeWitnessAddress(hrp, 16, witnessScript))
-                        else -> AddressFromPublicKeyScriptResult.Failure.InvalidScript
+                        is OP_1 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 1, witnessScript))
+                        is OP_2 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 2, witnessScript))
+                        is OP_3 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 3, witnessScript))
+                        is OP_4 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 4, witnessScript))
+                        is OP_5 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 5, witnessScript))
+                        is OP_6 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 6, witnessScript))
+                        is OP_7 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 7, witnessScript))
+                        is OP_8 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 8, witnessScript))
+                        is OP_9 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 9, witnessScript))
+                        is OP_10 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 10, witnessScript))
+                        is OP_11 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 11, witnessScript))
+                        is OP_12 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 12, witnessScript))
+                        is OP_13 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 13, witnessScript))
+                        is OP_14 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 14, witnessScript))
+                        is OP_15 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 15, witnessScript))
+                        is OP_16 -> Either.Right(Bech32.encodeWitnessAddress(hrp, 16, witnessScript))
+                        else -> return Either.Left(BitcoinException.InvalidScript)
                     }
                 }
 
-                else -> AddressFromPublicKeyScriptResult.Failure.InvalidScript
+                else -> return Either.Left(BitcoinException.InvalidScript)
             }
         } catch (t: Throwable) {
-            return AddressFromPublicKeyScriptResult.Failure.GenericError(t)
+            return Either.Left(BitcoinException.GenericError("", t))
         }
     }
 
     @JvmStatic
-    public fun addressFromPublicKeyScript(chainHash: BlockHash, pubkeyScript: ByteArray): AddressFromPublicKeyScriptResult {
+    public fun addressFromPublicKeyScript(chainHash: BlockHash, pubkeyScript: ByteArray): Either<BitcoinException, String> {
         return runCatching { Script.parse(pubkeyScript) }.fold(
             onSuccess = {
                 addressFromPublicKeyScript(chainHash, it)
             },
             onFailure = {
-                AddressFromPublicKeyScriptResult.Failure.InvalidScript
+                Either.Left(BitcoinException.InvalidScript)
             }
         )
     }
 
     @JvmStatic
-    public fun addressToPublicKeyScript(chainHash: BlockHash, address: String): AddressToPublicKeyScriptResult {
+    public fun addressToPublicKeyScript(chainHash: BlockHash, address: String): Either<BitcoinException, List<ScriptElt>> {
         val witnessVersions = mapOf(
             0.toByte() to OP_0,
             1.toByte() to OP_1,
@@ -216,18 +168,18 @@ public object Bitcoin {
             onSuccess = {
                 when {
                     it.first == Base58.Prefix.PubkeyAddressTestnet && (chainHash == Block.TestnetGenesisBlock.hash || chainHash == Block.RegtestGenesisBlock.hash || chainHash == Block.SignetGenesisBlock.hash) ->
-                        AddressToPublicKeyScriptResult.Success(Script.pay2pkh(it.second))
+                        Either.Right(Script.pay2pkh(it.second))
 
                     it.first == Base58.Prefix.PubkeyAddress && chainHash == Block.LivenetGenesisBlock.hash ->
-                        AddressToPublicKeyScriptResult.Success(Script.pay2pkh(it.second))
+                        Either.Right(Script.pay2pkh(it.second))
 
                     it.first == Base58.Prefix.ScriptAddressTestnet && (chainHash == Block.TestnetGenesisBlock.hash || chainHash == Block.RegtestGenesisBlock.hash || chainHash == Block.SignetGenesisBlock.hash) ->
-                        AddressToPublicKeyScriptResult.Success(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
+                        Either.Right(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
 
                     it.first == Base58.Prefix.ScriptAddress && chainHash == Block.LivenetGenesisBlock.hash ->
-                        AddressToPublicKeyScriptResult.Success(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
+                        Either.Right(listOf(OP_HASH160, OP_PUSHDATA(it.second), OP_EQUAL))
 
-                    else -> AddressToPublicKeyScriptResult.Failure.ChainHashMismatch
+                    else -> Either.Left(BitcoinException.ChainHashMismatch)
                 }
             },
             onFailure = { _ ->
@@ -235,17 +187,17 @@ public object Bitcoin {
                     onSuccess = {
                         val witnessVersion = witnessVersions[it.second]
                         when {
-                            witnessVersion == null -> AddressToPublicKeyScriptResult.Failure.InvalidWitnessVersion(it.second.toInt())
-                            it.third.size != 20 && it.third.size != 32 -> AddressToPublicKeyScriptResult.Failure.InvalidBech32Address
-                            it.first == "bc" && chainHash == Block.LivenetGenesisBlock.hash -> AddressToPublicKeyScriptResult.Success(listOf(witnessVersion, OP_PUSHDATA(it.third)))
-                            it.first == "tb" && chainHash == Block.TestnetGenesisBlock.hash -> AddressToPublicKeyScriptResult.Success(listOf(witnessVersion, OP_PUSHDATA(it.third)))
-                            it.first == "tb" && chainHash == Block.SignetGenesisBlock.hash -> AddressToPublicKeyScriptResult.Success(listOf(witnessVersion, OP_PUSHDATA(it.third)))
-                            it.first == "bcrt" && chainHash == Block.RegtestGenesisBlock.hash -> AddressToPublicKeyScriptResult.Success(listOf(witnessVersion, OP_PUSHDATA(it.third)))
-                            else -> AddressToPublicKeyScriptResult.Failure.ChainHashMismatch
+                            witnessVersion == null -> Either.Left(BitcoinException.InvalidWitnessVersion(it.second.toInt()))
+                            it.third.size != 20 && it.third.size != 32 -> Either.Left(BitcoinException.InvalidBech32Address)
+                            it.first == "bc" && chainHash == Block.LivenetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "tb" && chainHash == Block.TestnetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "tb" && chainHash == Block.SignetGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            it.first == "bcrt" && chainHash == Block.RegtestGenesisBlock.hash -> Either.Right(listOf(witnessVersion, OP_PUSHDATA(it.third)))
+                            else -> Either.Left(BitcoinException.ChainHashMismatch)
                         }
                     },
                     onFailure = {
-                        AddressToPublicKeyScriptResult.Failure.InvalidAddress
+                        Either.Left(BitcoinException.InvalidAddress)
                     }
                 )
             }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/utils/Try.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/utils/Try.kt
@@ -1,0 +1,46 @@
+package fr.acinq.bitcoin.utils
+
+public sealed class Try<T> {
+    public abstract val isSuccess: Boolean
+    public val isFailure: Boolean get() = !isSuccess
+    public abstract fun get(): T
+    public abstract fun getOrElse(f: () -> T): T
+    public abstract fun recoverWith(f: () -> Try<T>): Try<T>
+    public abstract fun <R> map(f: (T) -> R): Try<R>
+
+    public data class Success<T>(val result: T) : Try<T>() {
+        override val isSuccess: Boolean = true
+        override fun get(): T = result
+        override fun getOrElse(f: () -> T): T = result
+        override fun recoverWith(f: () -> Try<T>): Try<T> = this
+        override fun <R> map(f: (T) -> R): Try<R> = runTrying { f(result) }
+    }
+
+    public data class Failure<T>(val error: Throwable) : Try<T>() {
+        override val isSuccess: Boolean = false
+        override fun get(): T = throw error
+        override fun getOrElse(f: () -> T): T = f()
+        override fun recoverWith(f: () -> Try<T>): Try<T> = f()
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <R> map(f: (T) -> R): Try<R> = this as Try<R>
+    }
+
+    public companion object {
+        public operator fun <T> invoke(block: () -> T): Try<T> = runTrying(block)
+    }
+}
+
+public inline fun <R> runTrying(block: () -> R): Try<R> =
+    try {
+        Try.Success(block())
+    } catch (e: Throwable) {
+        Try.Failure(e)
+    }
+
+public inline fun <T, R> T.runTrying(block: T.() -> R): Try<R> =
+    try {
+        Try.Success(block())
+    } catch (e: Throwable) {
+        Try.Failure(e)
+    }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/BIP86TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/BIP86TestsCommon.kt
@@ -23,7 +23,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey.value, ByteVector32("a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"))
         val script = listOf(OP_1, OP_PUSHDATA(outputKey.value))
         assertEquals(Script.write(script).byteVector(), ByteVector("5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script), AddressFromPublicKeyScriptResult.Success("bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr"))
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right, "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr")
 
         val key1 = DeterministicWallet.derivePrivateKey(accountKey, listOf(0L, 1L))
         assertEquals(key1.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/0/1")).secretkeybytes)
@@ -33,7 +33,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey1.value, ByteVector32("a82f29944d65b86ae6b5e5cc75e294ead6c59391a1edc5e016e3498c67fc7bbb"))
         val script1 = listOf(OP_1, OP_PUSHDATA(outputKey1.value))
         assertEquals(Script.write(script1).byteVector(), ByteVector("5120a82f29944d65b86ae6b5e5cc75e294ead6c59391a1edc5e016e3498c67fc7bbb"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script1), AddressFromPublicKeyScriptResult.Success("bc1p4qhjn9zdvkux4e44uhx8tc55attvtyu358kutcqkudyccelu0was9fqzwh"))
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script1).right, "bc1p4qhjn9zdvkux4e44uhx8tc55attvtyu358kutcqkudyccelu0was9fqzwh")
 
         val key2 = DeterministicWallet.derivePrivateKey(accountKey, listOf(1L, 0L))
         assertEquals(key2.secretkeybytes, DeterministicWallet.derivePrivateKey(master, KeyPath("m/86'/0'/0'/1/0")).secretkeybytes)
@@ -43,7 +43,7 @@ class BIP86TestsCommon {
         assertEquals(outputKey2.value, ByteVector32("882d74e5d0572d5a816cef0041a96b6c1de832f6f9676d9605c44d5e9a97d3dc"))
         val script2 = listOf(OP_1, OP_PUSHDATA(outputKey2.value))
         assertEquals(Script.write(script2).byteVector(), ByteVector("5120882d74e5d0572d5a816cef0041a96b6c1de832f6f9676d9605c44d5e9a97d3dc"))
-        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script2), AddressFromPublicKeyScriptResult.Success("bc1p3qkhfews2uk44qtvauqyr2ttdsw7svhkl9nkm9s9c3x4ax5h60wqwruhk7"))
+        assertEquals(Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script2).right, "bc1p3qkhfews2uk44qtvauqyr2ttdsw7svhkl9nkm9s9c3x4ax5h60wqwruhk7")
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/BitcoinTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/BitcoinTestsCommon.kt
@@ -71,10 +71,10 @@ class BitcoinTestsCommon {
         assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).right, Script.pay2pkh(pub))
 
         // wrong chain
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).left, BitcoinException.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.PubkeyAddress, pub.hash160())).left, BitcoinError.ChainHashMismatch)
 
         // p2sh
         val script = Script.write(Script.pay2wpkh(pub))
@@ -86,10 +86,10 @@ class BitcoinTestsCommon {
         assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))).right, Script.pay2sh(script))
 
         // wrong chain
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))).left, BitcoinException.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Base58Check.encode(Base58.Prefix.ScriptAddress, Crypto.hash160(script))).left, BitcoinError.ChainHashMismatch)
     }
 
     @Test
@@ -103,10 +103,10 @@ class BitcoinTestsCommon {
         assertEquals(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, pub.hash160())).right, Script.pay2wpkh(pub))
 
         // wrong chain
-        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, pub.hash160())).left, BitcoinException.ChainHashMismatch)
-        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, pub.hash160())).left, BitcoinException.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.SignetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, pub.hash160())).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("tb", 0, pub.hash160())).left, BitcoinError.ChainHashMismatch)
+        assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bcrt", 0, pub.hash160())).left, BitcoinError.ChainHashMismatch)
 
         val script = Script.write(Script.pay2wpkh(pub))
         assertEquals(addressToPublicKeyScript(Block.LivenetGenesisBlock.hash, Bech32.encodeWitnessAddress("bc", 0, Crypto.sha256(script))).right, Script.pay2wsh(script))

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/ScriptTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/ScriptTestsCommon.kt
@@ -30,7 +30,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2pkh(script))
         assertNull(Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wpkh(script) || Script.isPay2wsh(script))
-        assertEquals("1C6Rc3w25VHud3dLDamutaqfKWqhrLRTaD", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
+        assertEquals("1C6Rc3w25VHud3dLDamutaqfKWqhrLRTaD", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test
@@ -40,7 +40,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2sh(script))
         assertNull(Script.getWitnessVersion(script))
         assertFalse(Script.isPay2pkh(script) || Script.isPay2wpkh(script) || Script.isPay2wsh(script))
-        assertEquals("3DedZ8SErqfunkjqnv8Pta1MKgEuHi22W5", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
+        assertEquals("3DedZ8SErqfunkjqnv8Pta1MKgEuHi22W5", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test
@@ -50,7 +50,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2wpkh(script))
         assertEquals(0, Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2pkh(script) || Script.isPay2wsh(script))
-        assertEquals("bc1q0xcqpzrky6eff2g52qdye53xkk9jxkvrh6yhyw", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
+        assertEquals("bc1q0xcqpzrky6eff2g52qdye53xkk9jxkvrh6yhyw", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test
@@ -60,7 +60,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isPay2wsh(script))
         assertEquals(0, Script.getWitnessVersion(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wpkh(script) || Script.isPay2pkh(script))
-        assertEquals("bc1qdudnf8tla4fyptt3n9y9985tq64lqwzr37d4ywpqfzfhtt638glsqaednx", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
+        assertEquals("bc1qdudnf8tla4fyptt3n9y9985tq64lqwzr37d4ywpqfzfhtt638glsqaednx", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test
@@ -70,7 +70,7 @@ class ScriptTestsCommon {
         assertTrue(Script.isNativeWitnessScript(script))
         assertFalse(Script.isPay2sh(script) || Script.isPay2wsh(script) || Script.isPay2wpkh(script) || Script.isPay2pkh(script))
         assertEquals(1, Script.getWitnessVersion(script))
-        assertEquals("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).result)
+        assertEquals("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, script).right)
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
@@ -87,7 +87,7 @@ class TaprootTestsCommon {
         assertEquals(Script.pay2tr(internalKey, scripts = null), Script.parse(tx.txOut[1].publicKeyScript))
 
         // we want to spend
-        val outputScript = addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, "tb1pn3g330w4n5eut7d4vxq0pp303267qc6vg8d2e0ctjuqre06gs3yqnc5yx0").result!!
+        val outputScript = addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, "tb1pn3g330w4n5eut7d4vxq0pp303267qc6vg8d2e0ctjuqre06gs3yqnc5yx0").right!!
         val tx1 = Transaction(
             2,
             listOf(TxIn(OutPoint(tx, 1), TxIn.SEQUENCE_FINAL)),
@@ -188,7 +188,7 @@ class TaprootTestsCommon {
         val tmp = Transaction(
             version = 2,
             txIn = listOf(TxIn(OutPoint(fundingTx, 0), TxIn.SEQUENCE_FINAL)),
-            txOut = listOf(TxOut(fundingTx.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, "bcrt1qdtu5cwyngza8hw8s5uk2erlrkh8ceh3msp768v").result!!)),
+            txOut = listOf(TxOut(fundingTx.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, "bcrt1qdtu5cwyngza8hw8s5uk2erlrkh8ceh3msp768v").right!!)),
             lockTime = 0
         )
 
@@ -242,7 +242,7 @@ class TaprootTestsCommon {
         val script = Script.pay2tr(internalPubkey, scriptTree)
         val bip350Address = Bech32.encodeWitnessAddress(hrp(blockchain), 1.toByte(), tweakedKey.value.toByteArray())
         assertEquals(bip350Address, "tb1p78gx95syx0qz8w5nftk8t7nce78zlpqpsxugcvq5xpfy4tvn6rasd7wk0y")
-        val sweepPublicKeyScript = addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").result!!
+        val sweepPublicKeyScript = addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").right!!
 
         // see https://mempool.space/signet/tx/c284010f06b5182e9f4722ce3474980339b1fc76e5ff29ece812f5d2162595c1
         val fundingTx = Transaction.read(
@@ -251,7 +251,7 @@ class TaprootTestsCommon {
 
         // output #1 is the one we want to spend
         assertEquals(fundingTx.txOut[0].publicKeyScript, Script.write(script).byteVector())
-        assertEquals(addressToPublicKeyScript(blockchain, bip350Address).result, script)
+        assertEquals(addressToPublicKeyScript(blockchain, bip350Address).right, script)
 
         // spending with the key path: no need to provide any script
         val tx = run {
@@ -337,7 +337,7 @@ class TaprootTestsCommon {
             val tmp = Transaction(
                 version = 2,
                 txIn = listOf(TxIn(OutPoint(fundingTx3, 1), TxIn.SEQUENCE_FINAL)),
-                txOut = listOf(TxOut(fundingTx3.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").result!!)),
+                txOut = listOf(TxOut(fundingTx3.txOut[0].amount - Satoshi(5000), addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").right!!)),
                 lockTime = 0
             )
             val sig = Crypto.signTaprootScriptPath(privs[2], tmp, 0, listOf(fundingTx3.txOut[1]), SigHash.SIGHASH_DEFAULT, leaves[2].hash())


### PR DESCRIPTION
We already export an `Either` type, which can be reused by clients of this library.