### PR TITLE
Pulls the Chain inner-class out of the Bitcoin object

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Bitcoin.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Bitcoin.kt
@@ -234,18 +234,18 @@ public object Bitcoin {
             }
         )
     }
+}
 
-    public sealed class Chain(public val name: String, private val genesis: Block) {
-        public object Regtest : Chain("Regtest", Block.RegtestGenesisBlock)
-        public object Testnet : Chain("Testnet", Block.TestnetGenesisBlock)
-        public object Signet : Chain("Signet", Block.SignetGenesisBlock)
-        public object Mainnet : Chain("Mainnet", Block.LivenetGenesisBlock)
+public sealed class Chain(public val name: String, private val genesis: Block) {
+    public object Regtest : Chain("Regtest", Block.RegtestGenesisBlock)
+    public object Testnet : Chain("Testnet", Block.TestnetGenesisBlock)
+    public object Signet : Chain("Signet", Block.SignetGenesisBlock)
+    public object Mainnet : Chain("Mainnet", Block.LivenetGenesisBlock)
 
-        public fun isMainnet(): Boolean = this is Mainnet
-        public fun isTestnet(): Boolean = this is Testnet
+    public fun isMainnet(): Boolean = this is Mainnet
+    public fun isTestnet(): Boolean = this is Testnet
 
-        public val chainHash: BlockHash get() = genesis.hash
+    public val chainHash: BlockHash get() = genesis.hash
 
-        override fun toString(): String = name
-    }
+    override fun toString(): String = name
 }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/BitcoinTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/BitcoinTestsCommon.kt
@@ -125,9 +125,9 @@ class BitcoinTestsCommon {
 
     @Test
     fun `check Chain objects`() {
-        assertEquals(Block.RegtestGenesisBlock.hash, Bitcoin.Chain.Regtest.chainHash)
-        assertEquals(Block.SignetGenesisBlock.hash, Bitcoin.Chain.Signet.chainHash)
-        assertEquals(Block.TestnetGenesisBlock.hash, Bitcoin.Chain.Testnet.chainHash)
-        assertEquals(Block.LivenetGenesisBlock.hash, Bitcoin.Chain.Mainnet.chainHash)
+        assertEquals(Block.RegtestGenesisBlock.hash, Chain.Regtest.chainHash)
+        assertEquals(Block.SignetGenesisBlock.hash, Chain.Signet.chainHash)
+        assertEquals(Block.TestnetGenesisBlock.hash, Chain.Testnet.chainHash)
+        assertEquals(Block.LivenetGenesisBlock.hash, Chain.Mainnet.chainHash)
     }
 }


### PR DESCRIPTION
Kotlin inner classes are not supported in Swift, and require workarounds, which are not even possible if the class is used throughout a project. We should avoid inner classes as much as possible.

For example: if you have outer class `Foo` and inner class `Bar`, then `Foo.Bar` doesn't appear within Swift. But also any function that uses `Foo.Bar` as either a parameter or return type is also unavailable in Swift.

Note: This may be fixed with https://skie.touchlab.co, but it's better to not have to use a generator in the first place.