### PR TITLE
Update musig2 api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 group = "fr.acinq.bitcoin"
-version = "0.19.0"
+version = "0.20.0-SNAPSHOT"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
@@ -228,7 +228,18 @@ public object Musig2 {
         return SecretNonce.generate(sessionId, privateKey, privateKey.publicKey(), message = null, keyAggCache, extraInput = null)
     }
 
-    private fun taprootSession(tx: Transaction, inputIndex: Int, inputs: List<TxOut>, publicKeys: List<PublicKey>, publicNonces: List<IndividualNonce>, scriptTree: ScriptTree?): Either<Throwable, Session> {
+    /**
+     * Create a musig2 session for a given transaction input.
+     *
+     * @param tx transaction
+     * @param inputIndex transaction input index
+     * @param inputs outputs spent by this transaction
+     * @param publicKeys signers' public keys
+     * @param publicNonces signers' public nonces
+     * @param scriptTree tapscript tree of the transaction's input, if it has script paths.
+     */
+    @JvmStatic
+    public fun taprootSession(tx: Transaction, inputIndex: Int, inputs: List<TxOut>, publicKeys: List<PublicKey>, publicNonces: List<IndividualNonce>, scriptTree: ScriptTree?): Either<Throwable, Session> {
         return IndividualNonce.aggregate(publicNonces).flatMap { aggregateNonce ->
             val (aggregatePublicKey, keyAggCache) = KeyAggCache.create(publicKeys)
             val tweak = when (scriptTree) {


### PR DESCRIPTION
To use taproot in lightning (to implement simple taproot channels for example) we need:
- to create musig2 sessions to verify partial signatures when we cannot yet aggregate them into a full signature.
- to read/write tapscript script trees  