### PR TITLE
Upgrade build and publishing scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
           path: ~/.gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'adopt'
       - name: Check
         run: ./gradlew check

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -37,10 +37,10 @@ jobs:
           path: ~/.gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'adopt'
       - name: Check
         run: ./gradlew check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,10 @@ jobs:
           path: ~/.gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'adopt'
       - name: Check
         run: ./gradlew check

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeHostTest
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
 
 plugins {
-    kotlin("multiplatform") version "2.1.10"
+    kotlin("multiplatform") version "2.1.21"
     id("org.jetbrains.dokka") version "1.9.20"
     `maven-publish`
 }
@@ -13,7 +13,7 @@ plugins {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 group = "fr.acinq.bitcoin"
-version = "0.24.0"
+version = "0.25.0"
 
 repositories {
     google()
@@ -28,6 +28,11 @@ kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
         }
+    }
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     linuxX64()
@@ -51,7 +56,7 @@ kotlin {
     }
 
     sourceSets {
-        val secp256k1KmpVersion = "0.17.3"
+        val secp256k1KmpVersion = "0.18.0"
 
         val commonMain by getting {
             dependencies {

--- a/publishing/bitcoin-kmp-staging-upload.sh
+++ b/publishing/bitcoin-kmp-staging-upload.sh
@@ -9,13 +9,15 @@ if [[ -z "${VERSION}" ]]; then
   exit 1
 fi
 
-if [[ -z "${OSS_USER}" ]]; then
-  echo "OSS_USER is not defined"
+if [[ -z "${CENTRAL_TOKEN_GPG_FILE}" ]]; then
+  echo "CENTRAL_TOKEN_GPG_FILE is not defined"
   exit 1
 fi
 
-read -p "Password : " -s OSS_PASSWORD
+CENTRAL_TOKEN=$(gpg --decrypt $CENTRAL_TOKEN_GPG_FILE)
 
+pushd .
+cd release
 for i in 	bitcoin-kmp \
 		bitcoin-kmp-iosarm64 \
 		bitcoin-kmp-iossimulatorarm64 \
@@ -26,10 +28,20 @@ for i in 	bitcoin-kmp \
 		bitcoin-kmp-macosarm64 \
 		bitcoin-kmp-macosx64
 do
-	pushd .
-	cd release/fr/acinq/bitcoin/$i/$VERSION &&\
-	pwd &&\
-	jar -cvf bundle.jar *&&\
-	curl -v -XPOST -u $OSS_USER:$OSS_PASSWORD --upload-file bundle.jar https://oss.sonatype.org/service/local/staging/bundle_upload	
-  popd
+	DIR=fr/acinq/bitcoin/$i/$VERSION
+	case $1 in
+	  create)
+  	  for file in $DIR/*
+	    do
+	      sha1sum $file | sed 's/ .*//' > $file.sha1
+	      md5sum $file | sed 's/ .*//' > $file.md5
+	      gpg -ab $file
+      done
+	    zip -r $i.zip $DIR
+	  ;;
+  	upload)
+	    curl --request POST --verbose --header "Authorization: Bearer ${CENTRAL_TOKEN}" --form bundle=@$i.zip https://central.sonatype.com/api/v1/publisher/upload
+    ;;
+  esac
 done
+popd

--- a/src/jvmTest/java/fr/acinq/bitcoin/crypto/CryptoJavaTests.java
+++ b/src/jvmTest/java/fr/acinq/bitcoin/crypto/CryptoJavaTests.java
@@ -11,22 +11,22 @@ public class CryptoJavaTests {
 
     @Test
     public void sha1() {
-        final var bytes = Digest.sha1().hash("This is a test!".getBytes(StandardCharsets.UTF_8));
-        final var hex = Hex.encode(bytes);
+        final byte[] bytes = Digest.sha1().hash("This is a test!".getBytes(StandardCharsets.UTF_8));
+        final String hex = Hex.encode(bytes);
         assertEquals("8b6ccb43dca2040c3cfbcd7bfff0b387d4538c33", hex);
     }
 
     @Test
     public void sha256() {
-        final var bytes = Digest.sha256().hash("This is a test!".getBytes(StandardCharsets.UTF_8));
-        final var hex = Hex.encode(bytes);
+        final byte[] bytes = Digest.sha256().hash("This is a test!".getBytes(StandardCharsets.UTF_8));
+        final String hex = Hex.encode(bytes);
         assertEquals("54ba1fdce5a89e0d3eee6e4c587497833bc38c3586ff02057dd6451fd2d6b640", hex);
     }
 
     @Test
     public void sha512() {
-        final var bytes = Digest.sha512().hash("This is a test!".getBytes(StandardCharsets.UTF_8));
-        final var hex = Hex.encode(bytes);
+        final byte[] bytes = Digest.sha512().hash("This is a test!".getBytes(StandardCharsets.UTF_8));
+        final String hex = Hex.encode(bytes);
         assertEquals("d4d6331e89ced845639272bc64ca3ef4e94a57c88431c61aef91f4399e30c6ada32c042f72cedad9cb1c7cfaf04d92e06ad044b557ca16f554f1c6d66b06d0e0", hex);
     }
 

--- a/src/jvmTest/java/fr/acinq/bitcoin/crypto/Pbkdf2JavaTests.java
+++ b/src/jvmTest/java/fr/acinq/bitcoin/crypto/Pbkdf2JavaTests.java
@@ -9,9 +9,9 @@ public class Pbkdf2JavaTests {
 
     @Test
     public void withHmacSha512() {
-        final var password = Hex.decode("6162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e2061626f7574");
-        final var salt = Hex.decode("6d6e656d6f6e6963");
-        final var result = Pbkdf2.withHmacSha512(password, salt, 2048, 64);
+        final byte[] password = Hex.decode("6162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e206162616e646f6e2061626f7574");
+        final byte[] salt = Hex.decode("6d6e656d6f6e6963");
+        final byte[] result = Pbkdf2.withHmacSha512(password, salt, 2048, 64);
         assertEquals("5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4", Hex.encode(result));
     }
 


### PR DESCRIPTION
Upgrade to Kotlin 2.1.21.
Upgrade to secp256k1-kmp 0.18.0.
Migrate publishing scripts from OSSRH to Central Publisher API.