### PR TITLE
Set compiler option to target java 1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,12 +13,11 @@ plugins {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 group = "fr.acinq.bitcoin"
-version = "0.25.0"
+version = "0.25.1-SNAPSHOT"
 
 repositories {
     google()
     mavenCentral()
-    maven(url="https://oss.sonatype.org/content/repositories/snapshots/")
 }
 
 kotlin {
@@ -27,6 +26,8 @@ kotlin {
     jvm {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
+            // See https://jakewharton.com/kotlins-jdk-release-compatibility-flag/ and https://youtrack.jetbrains.com/issue/KT-49746/
+            freeCompilerArgs.add("-Xjdk-release=1.8")
         }
     }
 

--- a/publishing/bitcoin-kmp-snapshot-deploy.sh
+++ b/publishing/bitcoin-kmp-snapshot-deploy.sh
@@ -11,7 +11,7 @@ fi
 cd snapshot
 pushd .
 cd fr/acinq/bitcoin/bitcoin-kmp/$VERSION
-mvn deploy:deploy-file -DrepositoryId=ossrh -Durl=https://oss.sonatype.org/content/repositories/snapshots/ \
+mvn deploy:deploy-file -DrepositoryId=central_portal -Durl=https://central.sonatype.com/repository/maven-snapshots/ \
   -DpomFile=$ARTIFACT_ID_BASE-$VERSION.pom \
   -Dfile=$ARTIFACT_ID_BASE-$VERSION.jar \
   -Dfiles=$ARTIFACT_ID_BASE-$VERSION.module,$ARTIFACT_ID_BASE-$VERSION-kotlin-tooling-metadata.json \
@@ -26,7 +26,7 @@ for i in iosarm64 iossimulatorarm64 iosx64 macosarm64 macosx64 jvm linuxx64 linu
 
   case $i in
     iosarm64 |iossimulatorarm64 | iosx64)
-      mvn deploy:deploy-file -DrepositoryId=ossrh -Durl=https://oss.sonatype.org/content/repositories/snapshots/ \
+      mvn deploy:deploy-file -DrepositoryId=central_portal -Durl=https://central.sonatype.com/repository/maven-snapshots/ \
         -DpomFile=$ARTIFACT_ID_BASE-$i-$VERSION.pom \
         -Dfile=$ARTIFACT_ID_BASE-$i-$VERSION.klib \
         -Dfiles=$ARTIFACT_ID_BASE-$i-$VERSION-metadata.jar,$ARTIFACT_ID_BASE-$i-$VERSION.module,$ARTIFACT_ID_BASE-$i-$VERSION-cinterop-CoreCrypto.klib \
@@ -36,7 +36,7 @@ for i in iosarm64 iossimulatorarm64 iosx64 macosarm64 macosx64 jvm linuxx64 linu
         -Djavadoc=$ARTIFACT_ID_BASE-$i-$VERSION-javadoc.jar
       ;;
     macosarm64 | macosx64)
-      mvn deploy:deploy-file -DrepositoryId=ossrh -Durl=https://oss.sonatype.org/content/repositories/snapshots/ \
+      mvn deploy:deploy-file -DrepositoryId=central_portal -Durl=https://central.sonatype.com/repository/maven-snapshots/ \
         -DpomFile=$ARTIFACT_ID_BASE-$i-$VERSION.pom \
         -Dfile=$ARTIFACT_ID_BASE-$i-$VERSION.klib \
         -Dfiles=$ARTIFACT_ID_BASE-$i-$VERSION-metadata.jar,$ARTIFACT_ID_BASE-$i-$VERSION.module \
@@ -46,7 +46,7 @@ for i in iosarm64 iossimulatorarm64 iosx64 macosarm64 macosx64 jvm linuxx64 linu
         -Djavadoc=$ARTIFACT_ID_BASE-$i-$VERSION-javadoc.jar
       ;;
     linuxx64 | linuxarm64)
-      mvn deploy:deploy-file -DrepositoryId=ossrh -Durl=https://oss.sonatype.org/content/repositories/snapshots/ \
+      mvn deploy:deploy-file -DrepositoryId=central_portal -Durl=https://central.sonatype.com/repository/maven-snapshots/ \
         -DpomFile=$ARTIFACT_ID_BASE-$i-$VERSION.pom \
         -Dfile=$ARTIFACT_ID_BASE-$i-$VERSION.klib \
         -Dfiles=$ARTIFACT_ID_BASE-$i-$VERSION.module \
@@ -56,7 +56,7 @@ for i in iosarm64 iossimulatorarm64 iosx64 macosarm64 macosx64 jvm linuxx64 linu
         -Djavadoc=$ARTIFACT_ID_BASE-$i-$VERSION-javadoc.jar
       ;;
     *)
-      mvn deploy:deploy-file -DrepositoryId=ossrh -Durl=https://oss.sonatype.org/content/repositories/snapshots/ \
+      mvn deploy:deploy-file -DrepositoryId=central_portal -Durl=https://central.sonatype.com/repository/maven-snapshots/ \
         -DpomFile=$ARTIFACT_ID_BASE-$i-$VERSION.pom \
         -Dfile=$ARTIFACT_ID_BASE-$i-$VERSION.jar \
         -Dfiles=$ARTIFACT_ID_BASE-$i-$VERSION.module \


### PR DESCRIPTION
Setting `jvmTarget` to target java 1.8 is not enough, Android apps may fail with an error like:

```
java.lang.NoSuchMethodError: No interface method removeFirst()Ljava/lang/Object; in class Ljava/util/List; or its super classes (declaration of 'java.util.List' appears in /system/framework/core-oj.jar)
``` 

 see https://jakewharton.com/kotlins-jdk-release-compatibility-flag/ and https://youtrack.jetbrains.com/issue/KT-49746/.
