### PR TITLE
Fix parser, signing, and MuSig2 issues

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/BtcSerializer.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/BtcSerializer.kt
@@ -167,12 +167,15 @@ public abstract class BtcSerializer<T> {
         }
 
         @JvmStatic
-        public fun bytes(input: Input, size: Long): ByteArray = bytes(input, size.toInt())
+        public fun bytes(input: Input, size: Long): ByteArray {
+            require(size in 0..Int.MAX_VALUE.toLong()) { "invalid size: $size" }
+            return bytes(input, size.toInt())
+        }
 
         @JvmStatic
         public fun bytes(input: Input, size: Int): ByteArray {
             // NB: we make that check before allocating a byte array, otherwise an attacker can exhaust our heap space.
-            require(size <= input.availableBytes) { "cannot read $size bytes from a stream that has ${input.availableBytes} bytes left" }
+            require(size in 0..input.availableBytes) { "cannot read $size bytes from a stream that has ${input.availableBytes} bytes left" }
             val blob = ByteArray(size)
             if (size > 0) {
                 input.read(blob, 0, size)
@@ -192,6 +195,7 @@ public abstract class BtcSerializer<T> {
         @JvmStatic
         public fun varstring(input: Input): String {
             val length = varint(input)
+            require(length <= Int.MAX_VALUE.toULong()) { "varstring length $length exceeds maximum" }
             val bytes = bytes(input, length.toInt())
             val chars = bytes.map { it.toInt().toChar() }.toCharArray()
             return chars.concatToString()
@@ -208,8 +212,9 @@ public abstract class BtcSerializer<T> {
 
         @JvmStatic
         public fun script(input: Input): ByteArray {
-            val length = varint(input) // read size
-            return bytes(input, length.toInt()) // read bytes
+            val length = varint(input)
+            require(length <= Int.MAX_VALUE.toULong()) { "script length $length exceeds maximum" }
+            return bytes(input, length.toInt())
         }
 
         @JvmStatic
@@ -236,7 +241,9 @@ public abstract class BtcSerializer<T> {
             maxElement: Int?,
             protocolVersion: Long
         ): List<T> {
-            val count = varint(input).toInt()
+            val rawCount = varint(input)
+            require(rawCount <= Int.MAX_VALUE.toULong()) { "collection count $rawCount exceeds maximum" }
+            val count = rawCount.toInt()
             if (maxElement != null) require(count <= maxElement) { "invalid length" }
             val items = mutableListOf<T>()
             for (i in 1..count) {

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Crypto.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Crypto.kt
@@ -216,13 +216,13 @@ public object Crypto {
         if (sig[1] != (sig.size - 3).toByte()) return false
 
         // Extract the length of the R element.
-        val lenR = sig[3]
+        val lenR = sig[3].toInt() and 0xff
 
         // Make sure the length of the S element is still inside the signature.
         if (5 + lenR >= sig.size) return false
 
         // Extract the length of the S element.
-        val lenS = sig[5 + lenR]
+        val lenS = sig[5 + lenR].toInt() and 0xff
 
         // Verify that the length of the signature matches the sum of the length
         // of the elements.
@@ -232,7 +232,7 @@ public object Crypto {
         if (sig[2] != 0x02.toByte()) return false
 
         // Zero-length integers are not allowed for R.
-        if (lenR == 0.toByte()) return false
+        if (lenR == 0) return false
 
         // Negative numbers are not allowed for R.
         if ((sig[4].toInt() and 0x80) != 0) return false
@@ -245,7 +245,7 @@ public object Crypto {
         if (sig[lenR + 4] != 0x02.toByte()) return false
 
         // Zero-length integers are not allowed for S.
-        if (lenS == 0.toByte()) return false
+        if (lenS == 0) return false
 
         // Negative numbers are not allowed for S.
         if ((sig[lenR + 6].toInt() and 0x80) != 0) return false
@@ -318,23 +318,23 @@ public object Crypto {
      * @return a compact 64 bytes signature
      */
     @JvmStatic
-    public fun decodeSignatureLax(derSignature: ByteArray): ByteVector64 {
+    public fun decodeSignatureLax(derSignature: ByteArray): ByteVector64 = try {
         var pos = 0
         val output = ByteArray(64)
 
         /* Sequence tag byte */
         require(derSignature[pos++] == 0x30.toByte())
 
-        var lenbyte = derSignature[pos++].toInt()
+        var lenbyte = derSignature[pos++].toInt() and 0xff
         if (lenbyte and 0x80 != 0) {
-            lenbyte -= 0x80;
-            pos += lenbyte;
+            lenbyte -= 0x80
+            pos += lenbyte
         }
 
         require(derSignature[pos++] == 0x02.toByte())
 
         fun readLength(): Int {
-            lenbyte = derSignature[pos++].toInt()
+            lenbyte = derSignature[pos++].toInt() and 0xff
             var len = 0
             if (lenbyte and 0x80 != 0) {
                 lenbyte -= 0x80
@@ -344,12 +344,12 @@ public object Crypto {
                 }
                 require(lenbyte < 4)
                 while (lenbyte > 0) {
-                    len = (len shl 8) + derSignature[pos]
+                    len = (len shl 8) + (derSignature[pos].toInt() and 0xff)
                     pos++
                     lenbyte--
                 }
             } else {
-                len = lenbyte;
+                len = lenbyte
             }
             return len
         }
@@ -388,7 +388,11 @@ public object Crypto {
         /* Copy S value */
         derSignature.copyInto(output, 64 - slen, spos, spos + slen)
 
-        return output.byteVector64()
+        output.byteVector64()
+    } catch (_: IllegalArgumentException) {
+        ByteVector64.Zeroes
+    } catch (_: IndexOutOfBoundsException) {
+        ByteVector64.Zeroes
     }
 
     /**

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
@@ -690,6 +690,7 @@ public data class Transaction(
         }
         val outputType = if (sighashType == SigHash.SIGHASH_DEFAULT) SigHash.SIGHASH_ALL else sighashType and SigHash.SIGHASH_OUTPUT_MASK
         if (outputType == SigHash.SIGHASH_SINGLE) {
+            require(inputIndex < txOut.size) { "SIGHASH_SINGLE requires a corresponding output" }
             out.write(Crypto.sha256(TxOut.write(txOut[inputIndex])))
         }
         if (sigVersion == SigVersion.SIGVERSION_TAPSCRIPT) {

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
@@ -68,17 +68,9 @@ public data class Session(private val data: ByteVector, private val keyAggCache:
     /**
      * @param secretNonce signer's secret nonce (see [SecretNonce.generate]).
      * @param privateKey signer's private key.
-     * @return a musig2 partial signature.
-     */
-    public fun sign(secretNonce: SecretNonce, privateKey: PrivateKey): ByteVector32 =
-        signEither(secretNonce, privateKey).getOrElse { throw it }
-
-    /**
-     * @param secretNonce signer's secret nonce (see [SecretNonce.generate]).
-     * @param privateKey signer's private key.
      * @return a musig2 partial signature, or an error if the nonce has already been used or signing fails.
      */
-    public fun signEither(secretNonce: SecretNonce, privateKey: PrivateKey): Either<Throwable, ByteVector32> =
+    public fun sign(secretNonce: SecretNonce, privateKey: PrivateKey): Either<Throwable, ByteVector32> =
         secretNonce.consume { nonce ->
             Secp256k1.musigPartialSign(nonce, privateKey.value.toByteArray(), keyAggCache.toByteArray(), this.toByteArray()).byteVector32()
         }
@@ -137,8 +129,7 @@ public class SecretNonce private constructor(bytes: ByteArray, offset: Int, size
 
     internal val data: ByteArray = bytes.copyOfRange(offset, offset + size)
 
-    public constructor(bin: ByteArray) : this(bin, 0, bin.size)
-    public constructor(hex: String) : this(Hex.decode(hex))
+    internal constructor(bin: ByteArray) : this(bin, 0, bin.size)
 
     override fun toString(): String = "<secret_nonce>"
 
@@ -381,7 +372,7 @@ public object Musig2 {
         publicNonces: List<IndividualNonce>,
         scriptTree: ScriptTree?
     ): Either<Throwable, ByteVector32> {
-        return taprootSession(tx, inputIndex, inputs, publicKeys, publicNonces, scriptTree).flatMap { it.signEither(secretNonce, privateKey) }
+        return taprootSession(tx, inputIndex, inputs, publicKeys, publicNonces, scriptTree).flatMap { it.sign(secretNonce, privateKey) }
     }
 
     /**

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
@@ -71,7 +71,7 @@ public data class Session(private val data: ByteVector, private val keyAggCache:
      * @return a musig2 partial signature.
      */
     public fun sign(secretNonce: SecretNonce, privateKey: PrivateKey): ByteVector32 {
-        return Secp256k1.musigPartialSign(secretNonce.data.toByteArray(), privateKey.value.toByteArray(), keyAggCache.toByteArray(), this.toByteArray()).byteVector32()
+        return Secp256k1.musigPartialSign(secretNonce.consume(), privateKey.value.toByteArray(), keyAggCache.toByteArray(), this.toByteArray()).byteVector32()
     }
 
     /**
@@ -119,15 +119,31 @@ public data class Session(private val data: ByteVector, private val keyAggCache:
  * Musig2 secret nonce, that should be treated as a private opaque blob.
  * This nonce must never be persisted or reused across signing sessions.
  */
-public data class SecretNonce(internal val data: ByteVector) {
-    public constructor(bin: ByteArray) : this(bin.byteVector())
-    public constructor(hex: String) : this(Hex.decode(hex))
+public class SecretNonce private constructor(internal val data: ByteArray, @Suppress("UNUSED_PARAMETER") copied: Boolean) {
+    public constructor(bin: ByteArray) : this(bin.copyOf(), true)
+    public constructor(hex: String) : this(Hex.decode(hex), true)
 
     init {
-        require(data.size() == Secp256k1.MUSIG2_SECRET_NONCE_SIZE) { "musig2 secret nonce must be ${Secp256k1.MUSIG2_SECRET_NONCE_SIZE} bytes" }
+        require(data.size == Secp256k1.MUSIG2_SECRET_NONCE_SIZE) { "musig2 secret nonce must be ${Secp256k1.MUSIG2_SECRET_NONCE_SIZE} bytes" }
     }
 
     override fun toString(): String = "<secret_nonce>"
+
+    private var consumed: Boolean = false
+
+    internal fun consume(): ByteArray {
+        check(!consumed) { "secret nonce has already been used" }
+        consumed = true
+        return data
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SecretNonce) return false
+        return data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int = data.contentHashCode()
 
     public companion object {
         /**

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
@@ -70,9 +70,18 @@ public data class Session(private val data: ByteVector, private val keyAggCache:
      * @param privateKey signer's private key.
      * @return a musig2 partial signature.
      */
-    public fun sign(secretNonce: SecretNonce, privateKey: PrivateKey): ByteVector32 {
-        return Secp256k1.musigPartialSign(secretNonce.consume(), privateKey.value.toByteArray(), keyAggCache.toByteArray(), this.toByteArray()).byteVector32()
-    }
+    public fun sign(secretNonce: SecretNonce, privateKey: PrivateKey): ByteVector32 =
+        signEither(secretNonce, privateKey).getOrElse { throw it }
+
+    /**
+     * @param secretNonce signer's secret nonce (see [SecretNonce.generate]).
+     * @param privateKey signer's private key.
+     * @return a musig2 partial signature, or an error if the nonce has already been used or signing fails.
+     */
+    public fun signEither(secretNonce: SecretNonce, privateKey: PrivateKey): Either<Throwable, ByteVector32> =
+        secretNonce.consume { nonce ->
+            Secp256k1.musigPartialSign(nonce, privateKey.value.toByteArray(), keyAggCache.toByteArray(), this.toByteArray()).byteVector32()
+        }
 
     /**
      * @param partialSig musig2 partial signature.
@@ -135,10 +144,14 @@ public class SecretNonce private constructor(bytes: ByteArray, offset: Int, size
 
     private var consumed: Boolean = false
 
-    internal fun consume(): ByteArray {
-        check(!consumed) { "secret nonce has already been used" }
+    internal fun <T> consume(block: (ByteArray) -> T): Either<Throwable, T> {
+        if (consumed) return Either.Left(IllegalStateException("secret nonce has already been used"))
         consumed = true
-        return data
+        return try {
+            Either.Right(block(data))
+        } catch (t: Throwable) {
+            Either.Left(t)
+        }
     }
 
     override fun equals(other: Any?): Boolean {
@@ -355,6 +368,7 @@ public object Musig2 {
      * @param secretNonce secret nonce of the signing participant.
      * @param publicNonces public nonces of all participants of the musig2 session.
      * @param scriptTree tapscript tree of the taproot input, if it has script paths.
+     * @return a partial signature, or an error if the nonce has already been used or session creation/signing fails.
      */
     @JvmStatic
     public fun signTaprootInput(
@@ -367,7 +381,7 @@ public object Musig2 {
         publicNonces: List<IndividualNonce>,
         scriptTree: ScriptTree?
     ): Either<Throwable, ByteVector32> {
-        return taprootSession(tx, inputIndex, inputs, publicKeys, publicNonces, scriptTree).map { it.sign(secretNonce, privateKey) }
+        return taprootSession(tx, inputIndex, inputs, publicKeys, publicNonces, scriptTree).flatMap { it.signEither(secretNonce, privateKey) }
     }
 
     /**

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
@@ -118,14 +118,18 @@ public data class Session(private val data: ByteVector, private val keyAggCache:
 /**
  * Musig2 secret nonce, that should be treated as a private opaque blob.
  * This nonce must never be persisted or reused across signing sessions.
+ * Application code should use [generate] or [generateWithCounter] to create fresh nonces.
  */
-public class SecretNonce private constructor(internal val data: ByteArray, @Suppress("UNUSED_PARAMETER") copied: Boolean) {
-    public constructor(bin: ByteArray) : this(bin.copyOf(), true)
-    public constructor(hex: String) : this(Hex.decode(hex), true)
-
+public class SecretNonce private constructor(bytes: ByteArray, offset: Int, size: Int) {
     init {
-        require(data.size == Secp256k1.MUSIG2_SECRET_NONCE_SIZE) { "musig2 secret nonce must be ${Secp256k1.MUSIG2_SECRET_NONCE_SIZE} bytes" }
+        require(size == Secp256k1.MUSIG2_SECRET_NONCE_SIZE) { "musig2 secret nonce must be ${Secp256k1.MUSIG2_SECRET_NONCE_SIZE} bytes" }
+        require(offset >= 0 && offset + size <= bytes.size) { "invalid secret nonce slice" }
     }
+
+    internal val data: ByteArray = bytes.copyOfRange(offset, offset + size)
+
+    public constructor(bin: ByteArray) : this(bin, 0, bin.size)
+    public constructor(hex: String) : this(Hex.decode(hex))
 
     override fun toString(): String = "<secret_nonce>"
 
@@ -165,7 +169,7 @@ public class SecretNonce private constructor(internal val data: ByteArray, @Supp
                 is Either.Right -> Pair(null, signingKey.value)
             }
             val nonce = Secp256k1.musigNonceGen(sessionId.toByteArray(), privateKey?.value?.toByteArray(), publicKey.value.toByteArray(), message?.toByteArray(), keyAggCache?.toByteArray(), extraInput?.toByteArray())
-            val secretNonce = SecretNonce(nonce.copyOfRange(0, Secp256k1.MUSIG2_SECRET_NONCE_SIZE))
+            val secretNonce = SecretNonce(nonce, 0, Secp256k1.MUSIG2_SECRET_NONCE_SIZE)
             val publicNonce = IndividualNonce(nonce.copyOfRange(Secp256k1.MUSIG2_SECRET_NONCE_SIZE, Secp256k1.MUSIG2_SECRET_NONCE_SIZE + Secp256k1.MUSIG2_PUBLIC_NONCE_SIZE))
             return Pair(secretNonce, publicNonce)
         }
@@ -206,7 +210,7 @@ public class SecretNonce private constructor(internal val data: ByteArray, @Supp
         @JvmStatic
         public fun generateWithCounter(nonRepeatingCounter: Long, privateKey: PrivateKey, message: ByteVector32?, keyAggCache: KeyAggCache?, extraInput: ByteVector32?): Pair<SecretNonce, IndividualNonce> {
             val nonce = Secp256k1.musigNonceGenCounter(nonRepeatingCounter.toULong(), privateKey.value.toByteArray(), message?.toByteArray(), keyAggCache?.toByteArray(), extraInput?.toByteArray())
-            val secretNonce = SecretNonce(nonce.copyOfRange(0, Secp256k1.MUSIG2_SECRET_NONCE_SIZE))
+            val secretNonce = SecretNonce(nonce, 0, Secp256k1.MUSIG2_SECRET_NONCE_SIZE)
             val publicNonce = IndividualNonce(nonce.copyOfRange(Secp256k1.MUSIG2_SECRET_NONCE_SIZE, Secp256k1.MUSIG2_SECRET_NONCE_SIZE + Secp256k1.MUSIG2_PUBLIC_NONCE_SIZE))
             return Pair(secretNonce, publicNonce)
         }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/psbt/Psbt.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/psbt/Psbt.kt
@@ -404,14 +404,16 @@ public data class Psbt(@JvmField val global: Global, @JvmField val inputs: List<
         }.getOrElse {
             return Either.Left(UpdateFailure.InvalidWitnessUtxo("failed to parse pubkeyScript"))
         }
+
+        fun signP2wpkh(program: List<ScriptElt>): Either<UpdateFailure, Pair<Input.WitnessInput.PartiallySignedWitnessInput, ByteVector>> {
+            val pubkeyHash = (program[1] as OP_PUSHDATA).data.toByteArray()
+            val signingScript = Script.pay2pkh(pubkeyHash)
+            val sig = ByteVector(Transaction.signInput(global.tx, inputIndex, signingScript, input.sighashType ?: SigHash.SIGHASH_ALL, input.amount, SigVersion.SIGVERSION_WITNESS_V0, priv))
+            return Either.Right(Pair(input.copy(partialSigs = input.partialSigs + (priv.publicKey() to sig)), sig))
+        }
+
         return when {
-            Script.isPay2wpkh(pubkeyScript) -> when (input.witnessScript) {
-                null -> Either.Left(UpdateFailure.InvalidWitnessUtxo("missing witness script"))
-                else -> {
-                    val sig = ByteVector(Transaction.signInput(global.tx, inputIndex, input.witnessScript, input.sighashType ?: SigHash.SIGHASH_ALL, input.amount, SigVersion.SIGVERSION_WITNESS_V0, priv))
-                    Either.Right(Pair(input.copy(partialSigs = input.partialSigs + (priv.publicKey() to sig)), sig))
-                }
-            }
+            Script.isPay2wpkh(pubkeyScript) -> signP2wpkh(pubkeyScript)
             Script.isPay2wsh(pubkeyScript) -> when {
                 input.witnessScript == null -> Either.Left(UpdateFailure.InvalidWitnessUtxo("missing witness script"))
                 pubkeyScript != Script.pay2wsh(input.witnessScript) -> Either.Left(UpdateFailure.InvalidWitnessUtxo("witness script does not match redeemScript or scriptPubKey"))
@@ -437,19 +439,16 @@ public data class Psbt(@JvmField val global: Global, @JvmField val inputs: List<
             Script.isPay2sh(pubkeyScript) -> when {
                 input.redeemScript == null -> Either.Left(UpdateFailure.InvalidWitnessUtxo("missing redeem script"))
                 pubkeyScript != Script.pay2sh(input.redeemScript) -> Either.Left(UpdateFailure.InvalidWitnessUtxo("redeem script does not match witness utxo scriptPubKey"))
-                else -> when {
-                    input.witnessScript == null -> {
-                        val sig = ByteVector(Transaction.signInput(global.tx, inputIndex, input.redeemScript, input.sighashType ?: SigHash.SIGHASH_ALL, input.amount, SigVersion.SIGVERSION_WITNESS_V0, priv))
-                        Either.Right(Pair(input.copy(partialSigs = input.partialSigs + (priv.publicKey() to sig)), sig))
-                    }
-                    !Script.isPay2wpkh(input.redeemScript) && input.redeemScript != Script.pay2wsh(input.witnessScript) -> {
-                        Either.Left(UpdateFailure.InvalidWitnessUtxo("witness script does not match redeemScript or scriptPubKey"))
-                    }
+                Script.isPay2wpkh(input.redeemScript) -> signP2wpkh(input.redeemScript)
+                Script.isPay2wsh(input.redeemScript) -> when {
+                    input.witnessScript == null -> Either.Left(UpdateFailure.InvalidWitnessUtxo("missing witness script"))
+                    input.redeemScript != Script.pay2wsh(input.witnessScript) -> Either.Left(UpdateFailure.InvalidWitnessUtxo("witness script does not match redeemScript or scriptPubKey"))
                     else -> {
                         val sig = ByteVector(Transaction.signInput(global.tx, inputIndex, input.witnessScript, input.sighashType ?: SigHash.SIGHASH_ALL, input.amount, SigVersion.SIGVERSION_WITNESS_V0, priv))
                         Either.Right(Pair(input.copy(partialSigs = input.partialSigs + (priv.publicKey() to sig)), sig))
                     }
                 }
+                else -> Either.Left(UpdateFailure.InvalidWitnessUtxo("redeem script is not a supported segwit witness program"))
             }
             else -> {
                 val script = input.witnessScript ?: input.redeemScript ?: pubkeyScript
@@ -1525,4 +1524,3 @@ public sealed class ParseFailure {
     public data class InvalidTxOutput(val reason: String) : ParseFailure()
     public object InvalidContent : ParseFailure()
 }
-

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/BtcSerializerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/BtcSerializerTestsCommon.kt
@@ -75,4 +75,36 @@ class BtcSerializerTestsCommon {
             assertFailsWith<IllegalArgumentException> { Script.write(listOf(it)) }
         }
     }
+
+    @Test
+    fun `reject oversized script lengths`() {
+        val input = ByteArrayInput(Hex.decode("fe00000080" + "00".repeat(100)))
+        assertFailsWith<IllegalArgumentException> {
+            BtcSerializer.script(input)
+        }
+    }
+
+    @Test
+    fun `reject oversized collection counts`() {
+        assertFailsWith<IllegalArgumentException> {
+            BtcSerializer.readCollection(ByteArrayInput(Hex.decode("ff0100000001000000")), TxOut, 10, Protocol.PROTOCOL_VERSION)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            BtcSerializer.readCollection(ByteArrayInput(Hex.decode("fe00000080")), TxOut, 10, Protocol.PROTOCOL_VERSION)
+        }
+    }
+
+    @Test
+    fun `reject transaction inputs with truncated script varints`() {
+        val outpointHash = "aa".repeat(32)
+        val outpointIndex = "00000000"
+        val scriptVarint = "ff0500000001000000"
+        val fiveScriptBytes = "0102030405"
+        val attackerSequence = "41414141"
+
+        val hex = outpointHash + outpointIndex + scriptVarint + fiveScriptBytes + attackerSequence
+        assertFailsWith<IllegalArgumentException> {
+            TxIn.read(Hex.decode(hex))
+        }
+    }
 }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/CryptoTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/CryptoTestsCommon.kt
@@ -150,6 +150,43 @@ class CryptoTestsCommon {
     }
 
     @Test
+    fun `strict DER validation rejects high-bit length bytes without crashing`() {
+        val sig = ByteArray(73)
+        sig[0] = 0x30
+        sig[1] = 0x46
+        sig[2] = 0x02
+        sig[3] = 0x80.toByte()
+
+        assertFalse(Crypto.isDERSignature(sig))
+    }
+
+    @Test
+    fun `lax DER decoder handles BER long-form sequence lengths`() {
+        val sig = ByteArray(71)
+        sig[0] = 0x30
+        sig[1] = 0x81.toByte()
+        sig[2] = 0x44
+        sig[3] = 0x02
+        sig[4] = 0x20
+        sig[37] = 0x02
+        sig[38] = 0x20
+
+        assertEquals(ByteVector64.Zeroes, Crypto.decodeSignatureLax(sig))
+    }
+
+    @Test
+    fun `lax DER decoder rejects malformed long-form integer lengths without throwing`() {
+        val sig = ByteArray(70)
+        sig[0] = 0x30
+        sig[1] = 0x44
+        sig[2] = 0x02
+        sig[3] = 0x81.toByte()
+        sig[4] = 0x20
+
+        assertEquals(ByteVector64.Zeroes, Crypto.decodeSignatureLax(sig))
+    }
+
+    @Test
     fun `generate deterministic signatures`() {
         val dataset = sequenceOf(
             Triple(

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
@@ -25,6 +25,27 @@ import kotlin.test.*
 
 class TaprootTestsCommon {
     @Test
+    fun `taproot SIGHASH_SINGLE without corresponding output is rejected`() {
+        val prevTxHash = TxHash("0000000000000000000000000000000000000000000000000000000000000001")
+        val tx = Transaction(
+            2,
+            listOf(
+                TxIn(OutPoint(prevTxHash, 0), ByteVector.empty, TxIn.SEQUENCE_FINAL),
+                TxIn(OutPoint(prevTxHash, 1), ByteVector.empty, TxIn.SEQUENCE_FINAL),
+                TxIn(OutPoint(prevTxHash, 2), ByteVector.empty, TxIn.SEQUENCE_FINAL),
+            ),
+            listOf(TxOut(50_000.sat(), ByteVector("76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac"))),
+            0
+        )
+        val inputs = List(3) { TxOut(50_000.sat(), ByteVector("76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac")) }
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            hashForSigningSchnorr(tx, 2, inputs, SigHash.SIGHASH_SINGLE, SigVersion.SIGVERSION_TAPROOT)
+        }
+        assertContains(exception.message ?: "", "corresponding output")
+    }
+
+    @Test
     fun `check taproot signatures`() {
         // derive BIP86 wallet key
         val (_, master) = DeterministicWallet.ExtendedPrivateKey.decode("tprv8ZgxMBicQKsPeQQADibg4WF7mEasy3piWZUHyThAzJCPNgMHDVYhTCVfev3jFbDhcYm4GimeFMbbi9z1d9rfY1aL5wfJ9mNebQ4thJ62EJb")

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
@@ -3,6 +3,7 @@ package fr.acinq.bitcoin.crypto.musig2
 import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.secp256k1.Hex
+import fr.acinq.secp256k1.Secp256k1
 import kotlinx.serialization.json.*
 import kotlin.random.Random
 import kotlin.test.*
@@ -258,6 +259,17 @@ class Musig2TestsCommon {
             val (_, keyagg) = KeyAggCache.create(keyIndices.map { pubkeys[it] })
             assertTrue(keyagg.tweak(tweak, isXonly).isLeft)
         }
+    }
+
+    @Test
+    fun `secret nonce constructors copy input data`() {
+        val rawNonce = ByteArray(Secp256k1.MUSIG2_SECRET_NONCE_SIZE) { it.toByte() }
+        val expectedNonce = rawNonce.copyOf()
+        val secretNonce = SecretNonce(rawNonce)
+
+        rawNonce.fill(0)
+
+        assertContentEquals(expectedNonce, secretNonce.data)
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
@@ -57,6 +57,8 @@ class Musig2TestsCommon {
         return SecretNonce(magic + serialized.take(64) + publicKeyX + publicKeyY)
     }
 
+    private fun deserializeSecretNonceBytes(hex: String): ByteArray = deserializeSecretNonce(hex).data.copyOf()
+
     @Test
     fun `generate secret nonce`() {
         val tests = TestHelpers.readResourceAsJson("musig2/nonce_gen_vectors.json")
@@ -129,7 +131,7 @@ class Musig2TestsCommon {
         val tests = TestHelpers.readResourceAsJson("musig2/sign_verify_vectors.json")
         val sk = PrivateKey.fromHex(tests.jsonObject["sk"]!!.jsonPrimitive.content)
         val pubkeys = tests.jsonObject["pubkeys"]!!.jsonArray.map { PublicKey(ByteVector(it.jsonPrimitive.content)) }
-        val secnonces = tests.jsonObject["secnonces"]!!.jsonArray.map { deserializeSecretNonce(it.jsonPrimitive.content) }
+        val secnonces = tests.jsonObject["secnonces"]!!.jsonArray.map { deserializeSecretNonceBytes(it.jsonPrimitive.content) }
         val pnonces = tests.jsonObject["pnonces"]!!.jsonArray.map { IndividualNonce(it.jsonPrimitive.content) }
         val aggnonces = tests.jsonObject["aggnonces"]!!.jsonArray.map { AggregatedNonce(it.jsonPrimitive.content) }
         val msgs = tests.jsonObject["msgs"]!!.jsonArray.map { ByteVector(it.jsonPrimitive.content) }
@@ -148,7 +150,7 @@ class Musig2TestsCommon {
             if (msgs[messageIndex].bytes.size == 32) {
                 val session = Session.create(aggnonce, ByteVector32(msgs[messageIndex]), keyagg)
                 assertNotNull(session)
-                val psig = session.sign(secnonces[keyIndices[signerIndex]], sk)
+                val psig = session.sign(SecretNonce(secnonces[keyIndices[signerIndex]]), sk)
                 assertEquals(expected, psig)
                 assertTrue(session.verify(psig, pnonces[nonceIndices[signerIndex]], pubkeys[keyIndices[signerIndex]]))
             }
@@ -224,7 +226,7 @@ class Musig2TestsCommon {
         val tweaks = tests.jsonObject["tweaks"]!!.jsonArray.map { ByteVector32.fromValidHex(it.jsonPrimitive.content) }
         val msg = ByteVector32.fromValidHex(tests.jsonObject["msg"]!!.jsonPrimitive.content)
 
-        val secnonce = deserializeSecretNonce(tests.jsonObject["secnonce"]!!.jsonPrimitive.content)
+        val secnonce = deserializeSecretNonceBytes(tests.jsonObject["secnonce"]!!.jsonPrimitive.content)
         val aggnonce = AggregatedNonce(tests.jsonObject["aggnonce"]!!.jsonPrimitive.content)
 
         assertEquals(pubkeys[0], sk.publicKey())
@@ -241,7 +243,7 @@ class Musig2TestsCommon {
             val keyagg = tweakIndices.fold(KeyAggCache.create(keyIndices.map { pubkeys[it] }).second) { keyAgg, tweakIdx -> keyAgg.tweak(tweaks[tweakIdx], isXonly[tweakIdx]).right!!.first }
             val session = Session.create(aggnonce, msg, keyagg)
             assertNotNull(session)
-            val psig = session.sign(secnonce, sk)
+            val psig = session.sign(SecretNonce(secnonce), sk)
             assertEquals(expected, psig)
             assertTrue(session.verify(psig, pnonces[nonceIndices[signerIndex]], pubkeys[keyIndices[signerIndex]]))
         }
@@ -255,6 +257,41 @@ class Musig2TestsCommon {
             val isXonly = it.jsonObject["is_xonly"]!!.jsonArray.map { it.jsonPrimitive.boolean }.first()
             val (_, keyagg) = KeyAggCache.create(keyIndices.map { pubkeys[it] })
             assertTrue(keyagg.tweak(tweak, isXonly).isLeft)
+        }
+    }
+
+    @Test
+    fun `secret nonces are single use`() {
+        val alicePrivKey = PrivateKey(ByteArray(32) { 1 })
+        val bobPrivKey = PrivateKey(ByteArray(32) { 2 })
+        val pubkeys = listOf(alicePrivKey.publicKey(), bobPrivKey.publicKey())
+        val (_, keyAggCache) = KeyAggCache.create(pubkeys)
+
+        val (aliceSecNonce, alicePubNonce) = SecretNonce.generate(
+            Random.Default.nextBytes(32).byteVector32(),
+            Either.Left(alicePrivKey),
+            null,
+            keyAggCache,
+            null
+        )
+        val (_, bobPubNonce) = SecretNonce.generate(
+            Random.Default.nextBytes(32).byteVector32(),
+            Either.Left(bobPrivKey),
+            null,
+            keyAggCache,
+            null
+        )
+
+        val aggnonce = IndividualNonce.aggregate(listOf(alicePubNonce, bobPubNonce)).right
+        assertNotNull(aggnonce)
+
+        val firstSession = Session.create(aggnonce, ByteVector32(ByteArray(31) + byteArrayOf(1)), keyAggCache)
+        val firstSig = firstSession.sign(aliceSecNonce, alicePrivKey)
+        assertTrue(firstSession.verify(firstSig, alicePubNonce, alicePrivKey.publicKey()))
+
+        val secondSession = Session.create(aggnonce, ByteVector32(ByteArray(31) + byteArrayOf(2)), keyAggCache)
+        assertFailsWith<IllegalStateException> {
+            secondSession.sign(aliceSecNonce, alicePrivKey)
         }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
@@ -308,6 +308,63 @@ class Musig2TestsCommon {
     }
 
     @Test
+    fun `session signEither returns left when secret nonce is reused`() {
+        val alicePrivKey = PrivateKey(ByteArray(32) { 1 })
+        val bobPrivKey = PrivateKey(ByteArray(32) { 2 })
+        val pubkeys = listOf(alicePrivKey.publicKey(), bobPrivKey.publicKey())
+        val (_, keyAggCache) = KeyAggCache.create(pubkeys)
+
+        val (aliceSecNonce, alicePubNonce) = SecretNonce.generate(
+            Random.Default.nextBytes(32).byteVector32(),
+            Either.Left(alicePrivKey),
+            null,
+            keyAggCache,
+            null
+        )
+        val (_, bobPubNonce) = SecretNonce.generate(
+            Random.Default.nextBytes(32).byteVector32(),
+            Either.Left(bobPrivKey),
+            null,
+            keyAggCache,
+            null
+        )
+
+        val aggnonce = IndividualNonce.aggregate(listOf(alicePubNonce, bobPubNonce)).right
+        assertNotNull(aggnonce)
+
+        val firstSession = Session.create(aggnonce, ByteVector32(ByteArray(31) + byteArrayOf(1)), keyAggCache)
+        assertNotNull(firstSession.signEither(aliceSecNonce, alicePrivKey).right)
+
+        val secondSession = Session.create(aggnonce, ByteVector32(ByteArray(31) + byteArrayOf(2)), keyAggCache)
+        val error = assertIs<IllegalStateException>(secondSession.signEither(aliceSecNonce, alicePrivKey).left)
+        assertEquals("secret nonce has already been used", error.message)
+    }
+
+    @Test
+    fun `taproot signing returns left when secret nonce is reused`() {
+        val alicePrivKey = PrivateKey(ByteArray(32) { 1 })
+        val alicePubKey = alicePrivKey.publicKey()
+        val bobPrivKey = PrivateKey(ByteArray(32) { 2 })
+        val bobPubKey = bobPrivKey.publicKey()
+
+        val internalPubKey = Musig2.aggregateKeys(listOf(alicePubKey, bobPubKey))
+        val tx = Transaction(2, listOf(), listOf(TxOut(10_000.sat(), Script.pay2tr(internalPubKey, Crypto.TaprootTweak.KeyPathTweak))), 0)
+        val spendingTx = Transaction(2, listOf(TxIn(OutPoint(tx, 0), sequence = 0)), listOf(TxOut(10_000.sat(), Script.pay2wpkh(alicePubKey))), 0)
+
+        val aliceNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(alicePrivKey), listOf(alicePubKey, bobPubKey), null, null)
+        val bobNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(bobPrivKey), listOf(alicePubKey, bobPubKey), null, null)
+        val publicNonces = listOf(aliceNonce.second, bobNonce.second)
+
+        val firstSig = Musig2.signTaprootInput(alicePrivKey, spendingTx, 0, listOf(tx.txOut[0]), listOf(alicePubKey, bobPubKey), aliceNonce.first, publicNonces, scriptTree = null)
+        assertNotNull(firstSig.right)
+
+        val error = assertIs<IllegalStateException>(
+            Musig2.signTaprootInput(alicePrivKey, spendingTx, 0, listOf(tx.txOut[0]), listOf(alicePubKey, bobPubKey), aliceNonce.first, publicNonces, scriptTree = null).left
+        )
+        assertEquals("secret nonce has already been used", error.message)
+    }
+
+    @Test
     fun `simple musig2 example`() {
         val msg = Random.Default.nextBytes(32).byteVector32()
         val privkeys = listOf(

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
@@ -151,7 +151,7 @@ class Musig2TestsCommon {
             if (msgs[messageIndex].bytes.size == 32) {
                 val session = Session.create(aggnonce, ByteVector32(msgs[messageIndex]), keyagg)
                 assertNotNull(session)
-                val psig = session.sign(SecretNonce(secnonces[keyIndices[signerIndex]]), sk)
+                val psig = session.sign(SecretNonce(secnonces[keyIndices[signerIndex]]), sk).right!!
                 assertEquals(expected, psig)
                 assertTrue(session.verify(psig, pnonces[nonceIndices[signerIndex]], pubkeys[keyIndices[signerIndex]]))
             }
@@ -244,7 +244,7 @@ class Musig2TestsCommon {
             val keyagg = tweakIndices.fold(KeyAggCache.create(keyIndices.map { pubkeys[it] }).second) { keyAgg, tweakIdx -> keyAgg.tweak(tweaks[tweakIdx], isXonly[tweakIdx]).right!!.first }
             val session = Session.create(aggnonce, msg, keyagg)
             assertNotNull(session)
-            val psig = session.sign(SecretNonce(secnonce), sk)
+            val psig = session.sign(SecretNonce(secnonce), sk).right!!
             assertEquals(expected, psig)
             assertTrue(session.verify(psig, pnonces[nonceIndices[signerIndex]], pubkeys[keyIndices[signerIndex]]))
         }
@@ -298,45 +298,11 @@ class Musig2TestsCommon {
         assertNotNull(aggnonce)
 
         val firstSession = Session.create(aggnonce, ByteVector32(ByteArray(31) + byteArrayOf(1)), keyAggCache)
-        val firstSig = firstSession.sign(aliceSecNonce, alicePrivKey)
+        val firstSig = firstSession.sign(aliceSecNonce, alicePrivKey).right!!
         assertTrue(firstSession.verify(firstSig, alicePubNonce, alicePrivKey.publicKey()))
 
         val secondSession = Session.create(aggnonce, ByteVector32(ByteArray(31) + byteArrayOf(2)), keyAggCache)
-        assertFailsWith<IllegalStateException> {
-            secondSession.sign(aliceSecNonce, alicePrivKey)
-        }
-    }
-
-    @Test
-    fun `session signEither returns left when secret nonce is reused`() {
-        val alicePrivKey = PrivateKey(ByteArray(32) { 1 })
-        val bobPrivKey = PrivateKey(ByteArray(32) { 2 })
-        val pubkeys = listOf(alicePrivKey.publicKey(), bobPrivKey.publicKey())
-        val (_, keyAggCache) = KeyAggCache.create(pubkeys)
-
-        val (aliceSecNonce, alicePubNonce) = SecretNonce.generate(
-            Random.Default.nextBytes(32).byteVector32(),
-            Either.Left(alicePrivKey),
-            null,
-            keyAggCache,
-            null
-        )
-        val (_, bobPubNonce) = SecretNonce.generate(
-            Random.Default.nextBytes(32).byteVector32(),
-            Either.Left(bobPrivKey),
-            null,
-            keyAggCache,
-            null
-        )
-
-        val aggnonce = IndividualNonce.aggregate(listOf(alicePubNonce, bobPubNonce)).right
-        assertNotNull(aggnonce)
-
-        val firstSession = Session.create(aggnonce, ByteVector32(ByteArray(31) + byteArrayOf(1)), keyAggCache)
-        assertNotNull(firstSession.signEither(aliceSecNonce, alicePrivKey).right)
-
-        val secondSession = Session.create(aggnonce, ByteVector32(ByteArray(31) + byteArrayOf(2)), keyAggCache)
-        val error = assertIs<IllegalStateException>(secondSession.signEither(aliceSecNonce, alicePrivKey).left)
+        val error = assertIs<IllegalStateException>(secondSession.sign(aliceSecNonce, alicePrivKey).left)
         assertEquals("secret nonce has already been used", error.message)
     }
 
@@ -395,7 +361,7 @@ class Musig2TestsCommon {
 
         // Create partial signatures from each participant.
         val session = Session.create(aggnonce, msg, keyAggCache)
-        val psigs = privkeys.indices.map { session.sign(secnonces[it], privkeys[it]) }
+        val psigs = privkeys.indices.map { session.sign(secnonces[it], privkeys[it]).right!! }
         // Verify individual partial signatures.
         pubkeys.indices.forEach { assertTrue(session.verify(psigs[it], pubnonces[it], pubkeys[it])) }
         // Aggregate partial signatures into a single signature.

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/psbt/PsbtTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/psbt/PsbtTestsCommon.kt
@@ -1534,6 +1534,107 @@ class PsbtTestsCommon {
         Transaction.correctlySpends(extracted.right!!, utxos, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     }
 
+    @Test
+    fun `P2WPKH signer derives scriptCode from the witness program`() {
+        val victimPrivKey = PrivateKey(ByteVector32("0101010101010101010101010101010101010101010101010101010101010101"))
+        val victimPubKey = victimPrivKey.publicKey()
+        val attackerPubKey = PrivateKey(ByteVector32("0202020202020202020202020202020202020202020202020202020202020202")).publicKey()
+
+        val inputTx = Transaction(2, listOf(), listOf(TxOut(100000.sat(), Script.pay2wpkh(victimPubKey))), 0)
+        val correctScriptCode = Script.pay2pkh(victimPubKey)
+        val attackerScript = Script.createMultiSigMofN(1, listOf(victimPubKey, attackerPubKey))
+        val spendingTx = Transaction(
+            2,
+            listOf(TxIn(OutPoint(inputTx, 0), ByteVector.empty, 0)),
+            listOf(TxOut(90000.sat(), Script.pay2wpkh(attackerPubKey))),
+            0
+        )
+
+        val maliciousPsbt = Psbt(spendingTx)
+            .updateWitnessInputTx(inputTx, 0, null, attackerScript, SIGHASH_ALL)
+            .right!!
+
+        val signResult = maliciousPsbt.sign(victimPrivKey, 0)
+        assertTrue(signResult.isRight)
+
+        val psbtSig = signResult.right!!.sig
+        val correctSig = ByteVector(
+            spendingTx.signInput(0, correctScriptCode, SIGHASH_ALL, 100000.sat(), SigVersion.SIGVERSION_WITNESS_V0, victimPrivKey)
+        )
+        val attackerSig = ByteVector(
+            spendingTx.signInput(0, attackerScript, SIGHASH_ALL, 100000.sat(), SigVersion.SIGVERSION_WITNESS_V0, victimPrivKey)
+        )
+
+        assertEquals(correctSig, psbtSig)
+        assertNotEquals(attackerSig, psbtSig)
+    }
+
+    @Test
+    fun `P2WPKH signature cannot be reused in a P2WSH context`() {
+        val victimPrivKey = PrivateKey(ByteVector32("0101010101010101010101010101010101010101010101010101010101010101"))
+        val victimPubKey = victimPrivKey.publicKey()
+        val attackerPubKey = PrivateKey(ByteVector32("0202020202020202020202020202020202020202020202020202020202020202")).publicKey()
+
+        val multisigScript = Script.createMultiSigMofN(1, listOf(victimPubKey, attackerPubKey))
+        val p2wshAmount = 500000.sat()
+        val p2wshTx = Transaction(2, listOf(), listOf(TxOut(p2wshAmount, Script.pay2wsh(multisigScript))), 0)
+        val stealTx = Transaction(
+            2,
+            listOf(TxIn(OutPoint(p2wshTx, 0), ByteVector.empty, 0)),
+            listOf(TxOut(490000.sat(), Script.pay2wpkh(attackerPubKey))),
+            0
+        )
+
+        val maliciousPsbt = Psbt(stealTx)
+            .updateWitnessInput(
+                OutPoint(p2wshTx, 0),
+                TxOut(p2wshAmount, Script.pay2wpkh(victimPubKey)),
+                witnessScript = multisigScript,
+                sighashType = SIGHASH_ALL
+            ).right!!
+
+        val signResult = maliciousPsbt.sign(victimPrivKey, 0)
+        assertTrue(signResult.isRight)
+
+        val extractedSig = signResult.right!!.sig
+        val legitimateP2wshSig = ByteVector(
+            stealTx.signInput(0, multisigScript, SIGHASH_ALL, p2wshAmount, SigVersion.SIGVERSION_WITNESS_V0, victimPrivKey)
+        )
+        assertNotEquals(legitimateP2wshSig, extractedSig)
+
+        val witness = Script.witnessMultiSigMofN(listOf(victimPubKey, attackerPubKey), listOf(extractedSig))
+        val finalTx = stealTx.updateWitness(0, ScriptWitness(witness.stack))
+        assertFails {
+            Transaction.correctlySpends(finalTx, listOf(p2wshTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+        }
+    }
+
+    @Test
+    fun `P2WPKH signing works without witnessScript`() {
+        val privKey = PrivateKey(ByteVector32("0101010101010101010101010101010101010101010101010101010101010101"))
+        val pubKey = privKey.publicKey()
+
+        val inputTx = Transaction(2, listOf(), listOf(TxOut(100000.sat(), Script.pay2wpkh(pubKey))), 0)
+        val spendingTx = Transaction(
+            2,
+            listOf(TxIn(OutPoint(inputTx, 0), ByteVector.empty, 0)),
+            listOf(TxOut(90000.sat(), Script.pay2wpkh(pubKey))),
+            0
+        )
+
+        val specCompliantPsbt = Psbt(spendingTx)
+            .updateWitnessInputTx(inputTx, 0, null, null, SIGHASH_ALL)
+            .right!!
+
+        val signResult = specCompliantPsbt.sign(privKey, 0)
+        assertTrue(signResult.isRight)
+
+        val expectedSig = ByteVector(
+            spendingTx.signInput(0, Script.pay2pkh(pubKey), SIGHASH_ALL, 100000.sat(), SigVersion.SIGVERSION_WITNESS_V0, privKey)
+        )
+        assertEquals(expectedSig, signResult.right!!.sig)
+    }
+
     private fun readValidPsbt(hex: String): Psbt {
         val result = Psbt.read(ByteVector(hex))
         assertTrue(result.isRight)


### PR DESCRIPTION
## Summary

This PR fixes five security issues in `bitcoin-kmp`. The bugs were all in malformed-input handling or signer safety boundaries: oversized varints could be truncated during deserialization, malformed DER length bytes could crash ECDSA verification, MuSig2 secret nonces could be reused after signing, P2WPKH PSBT signing trusted attacker-supplied `witnessScript`, and taproot `SIGHASH_SINGLE` could dereference an out-of-bounds output index.

None of these fixes should change valid Bitcoin encodings or normal signing flows. The changes harden the library against malformed or malicious inputs and tighten signer behavior so the library matches the security expectations of callers more closely.

## Fixes

### 1. Varint truncation in `BtcSerializer`
`BtcSerializer` previously converted `ULong` lengths and counts to `Int` with unchecked `.toInt()` calls. That allowed attacker-controlled varints to wrap to negative or small positive values, which could:
- bypass length checks
- crash on allocation
- misparse byte streams by consuming only a prefix of attacker-controlled data
- bypass `maxElement` limits for collections

This PR adds explicit bounds checks before every relevant narrowing conversion and rejects lengths or counts that exceed `Int.MAX_VALUE`.

### 2. Signed-byte DER parsing crash in `Crypto`
ECDSA DER parsing used signed `Byte` values directly in length and index arithmetic. Length bytes with the high bit set, including BER long-form lengths, could produce negative offsets and uncaught indexing errors during verification.

This PR masks DER length bytes to unsigned values and makes the lax decoder return an invalid signature result instead of crashing on malformed length encodings.

### 3. MuSig2 `SecretNonce` reuse in `Musig2`
`SecretNonce` was a `data class`, and signing passed a copied buffer into libsecp256k1. That meant native zeroization only affected the copy, while the original `SecretNonce` remained reusable. A caller mistake that reused the same nonce across sessions could expose the signer’s private key.

This PR makes `SecretNonce` single-use:
- signing now consumes the actual backing nonce buffer
- a second signing attempt with the same nonce fails
- `SecretNonce` is no longer a `data class`, so it no longer exposes `copy()` semantics for nonce duplication

### 4. P2WPKH PSBT script-code misbinding in `Psbt`
For P2WPKH inputs, the signer previously used `input.witnessScript` as the script code when present. That let a malicious PSBT coordinator substitute attacker-chosen script code and obtain a signature for a different segwit v0 spending context.

This PR fixes the P2WPKH signing path so it always derives script code from the actual witness program:
- native P2WPKH now signs `OP_DUP OP_HASH160 <20-byte program> OP_EQUALVERIFY OP_CHECKSIG`
- nested P2SH-P2WPKH now derives the same script code from the redeem script’s witness program
- spec-compliant P2WPKH PSBTs no longer require `witnessScript`

### 5. Taproot `SIGHASH_SINGLE` out-of-bounds access in `Transaction`
The taproot schnorr sighash path accessed `txOut[inputIndex]` without checking whether a corresponding output existed. For malformed transactions using `SIGHASH_SINGLE`, that caused an uncaught `IndexOutOfBoundsException`.

This PR adds an explicit guard so the failure is handled intentionally instead of reaching an out-of-bounds array access.

## Implementation notes

The main code changes are in:
- `BtcSerializer.kt`
- `Crypto.kt`
- `crypto/musig2/Musig2.kt`
- `psbt/Psbt.kt`
- `Transaction.kt`

The behavior of valid transactions, signatures, and PSBTs is unchanged. The changes only affect malformed or unsafe cases.

## Verification

Added regression coverage for each fix:
- oversized and truncating varints are rejected
- malformed DER/BER length bytes no longer crash verification helpers
- MuSig2 secret nonces cannot be reused
- P2WPKH PSBT signing derives script code from the witness program and works without `witnessScript`
- malformed taproot `SIGHASH_SINGLE` no longer reaches out-of-bounds output access

Verified with:

```bash
./gradlew jvmTest
```
