### PR TITLE
Add taproot and musig2 helpers for taproot gossip support

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Script.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Script.kt
@@ -402,6 +402,20 @@ public object Script {
     @JvmStatic
     public fun isPay2tr(script: ByteVector): Boolean = isPay2tr(script.toByteArray())
 
+    @JvmStatic
+    public fun pay2trOutputKey(script: List<ScriptElt>): XonlyPublicKey? {
+        return when {
+            !isPay2tr(script) -> null
+            else -> XonlyPublicKey(ByteVector32((script[1] as OP_PUSHDATA).data))
+        }
+    }
+
+    @JvmStatic
+    public fun pay2trOutputKey(script: ByteArray): XonlyPublicKey? = pay2trOutputKey(parse(script))
+
+    @JvmStatic
+    public fun pay2trOutputKey(script: ByteVector): XonlyPublicKey? = pay2trOutputKey(script.toByteArray())
+
     /**
      * @param pubKeyHash public key hash
      * @return a pay-to-public-key-hash script

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
@@ -345,7 +345,7 @@ public object Musig2 {
      * @return a partial signature, or an error if the nonce has already been used or session creation/signing fails.
      */
     @JvmStatic
-    public fun signMessage(privateKey: PrivateKey, secretNonce: SecretNonce, msg: ByteVector32, publicKeys: List<PublicKey>, publicNonces: List<IndividualNonce>): Either<Throwable, ByteVector32> {
+    public fun sign(privateKey: PrivateKey, secretNonce: SecretNonce, msg: ByteVector32, publicKeys: List<PublicKey>, publicNonces: List<IndividualNonce>): Either<Throwable, ByteVector32> {
         return signingSession(msg, publicKeys, publicNonces).flatMap { session ->
             session.sign(secretNonce, privateKey)
         }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2.kt
@@ -83,7 +83,7 @@ public data class Session(private val data: ByteVector, private val keyAggCache:
      */
     public fun verify(partialSig: ByteVector32, publicNonce: IndividualNonce, publicKey: PublicKey): Boolean = try {
         Secp256k1.musigPartialSigVerify(partialSig.toByteArray(), publicNonce.toByteArray(), publicKey.value.toByteArray(), keyAggCache.toByteArray(), this.toByteArray()) == 1
-    } catch (t: Throwable) {
+    } catch (_: Throwable) {
         false
     }
 
@@ -310,7 +310,7 @@ public object Musig2 {
     public fun generateNonce(sessionId: ByteVector32, privateKey: PrivateKey?, publicKey: PublicKey, publicKeys: List<PublicKey>, message: ByteVector32?, extraInput: ByteVector32?): Pair<SecretNonce, IndividualNonce> {
         privateKey?.let { require(it.publicKey() == publicKey) { "if the private key is provided, it must match the public key" } }
         val signingKey = privateKey?.let { Either.Left(it) } ?: Either.Right(publicKey)
-        return generateNonce(sessionId, signingKey, publicKeys, message,  extraInput)
+        return generateNonce(sessionId, signingKey, publicKeys, message, extraInput)
     }
 
     /**
@@ -324,6 +324,62 @@ public object Musig2 {
     public fun generateNonceWithCounter(nonRepeatingCounter: Long, privateKey: PrivateKey, publicKeys: List<PublicKey>, message: ByteVector32?, extraInput: ByteVector32?): Pair<SecretNonce, IndividualNonce> {
         val (_, keyAggCache) = KeyAggCache.create(publicKeys)
         return SecretNonce.generateWithCounter(nonRepeatingCounter, privateKey, message, keyAggCache, extraInput)
+    }
+
+    @JvmStatic
+    private fun signingSession(msg: ByteVector32, publicKeys: List<PublicKey>, publicNonces: List<IndividualNonce>): Either<Throwable, Session> {
+        return IndividualNonce.aggregate(publicNonces).map { aggregatedNonce ->
+            val (_, keyAggCache) = KeyAggCache.create(publicKeys)
+            Session.create(aggregatedNonce, msg, keyAggCache)
+        }
+    }
+
+    /**
+     * Create a partial musig2 signature for the given arbitrary message.
+     *
+     * @param privateKey private key of the signing participant.
+     * @param secretNonce secret nonce of the signing participant.
+     * @param msg message that should be signed.
+     * @param publicKeys public keys of all participants of the musig2 session: callers must verify that all public keys are valid.
+     * @param publicNonces public nonces of all participants of the musig2 session.
+     * @return a partial signature, or an error if the nonce has already been used or session creation/signing fails.
+     */
+    @JvmStatic
+    public fun signMessage(privateKey: PrivateKey, secretNonce: SecretNonce, msg: ByteVector32, publicKeys: List<PublicKey>, publicNonces: List<IndividualNonce>): Either<Throwable, ByteVector32> {
+        return signingSession(msg, publicKeys, publicNonces).flatMap { session ->
+            session.sign(secretNonce, privateKey)
+        }
+    }
+
+    /**
+     * Verify a partial musig2 signature of an arbitrary message.
+     *
+     * @param partialSig partial musig2 signature.
+     * @param nonce public nonce matching the secret nonce used to generate the signature.
+     * @param publicKey public key for the private key used to generate the signature.
+     * @param msg message signed.
+     * @param publicKeys public keys of all participants of the musig2 session: callers must verify that all public keys are valid.
+     * @param publicNonces public nonces of all participants of the musig2 session.
+     * @return true if the partial signature is valid.
+     */
+    @JvmStatic
+    public fun verify(partialSig: ByteVector32, nonce: IndividualNonce, publicKey: PublicKey, msg: ByteVector32, publicKeys: List<PublicKey>, publicNonces: List<IndividualNonce>): Boolean {
+        return signingSession(msg, publicKeys, publicNonces).map { session ->
+            session.verify(partialSig, nonce, publicKey)
+        }.getOrElse { false }
+    }
+
+    /**
+     * Aggregate partial musig2 signatures into a valid schnorr signature for the given arbitrary message.
+     *
+     * @param partialSigs partial musig2 signatures of all participants of the musig2 session.
+     * @param msg message signed.
+     * @param publicKeys public keys of all participants of the musig2 session: callers must verify that all public keys are valid.
+     * @param publicNonces public nonces of all participants of the musig2 session.
+     */
+    @JvmStatic
+    public fun aggregatePartialSignatures(partialSigs: List<ByteVector32>, msg: ByteVector32, publicKeys: List<PublicKey>, publicNonces: List<IndividualNonce>): Either<Throwable, ByteVector64> {
+        return signingSession(msg, publicKeys, publicNonces).flatMap { it.aggregateSigs(partialSigs) }
     }
 
     /**
@@ -377,7 +433,7 @@ public object Musig2 {
 
     /**
      * Verify a partial musig2 signature.
-
+     *
      * @param partialSig partial musig2 signature.
      * @param nonce public nonce matching the secret nonce used to generate the signature.
      * @param publicKey public key for the private key used to generate the signature.

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/SegwitTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/SegwitTestsCommon.kt
@@ -21,6 +21,7 @@ import fr.acinq.secp256k1.Hex
 import fr.acinq.secp256k1.Secp256k1
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SegwitTestsCommon {
@@ -61,7 +62,7 @@ class SegwitTestsCommon {
             600000000L.toSatoshi(),
             1
         )
-        assertTrue(Hex.encode(hash) == "c37af31116d1b27caf68aae9e3ac82f1477929014d5b917657d0eb49478cb670")
+        assertEquals(Hex.encode(hash), "c37af31116d1b27caf68aae9e3ac82f1477929014d5b917657d0eb49478cb670")
 
         val priv = PrivateKey.fromHex("619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb901")
         val pub = priv.publicKey()
@@ -72,7 +73,10 @@ class SegwitTestsCommon {
         val tx1 = tx.updateSigScript(0, sigScript)
         val tx2 = tx1.updateWitness(1, ScriptWitness(listOf(ByteVector(sig + SIGHASH_ALL.toByte()), pub.value)))
         val bin = Transaction.write(tx2, Protocol.PROTOCOL_VERSION)
-        assertTrue(Hex.encode(bin) == "01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000")
+        assertEquals(
+            Hex.encode(bin),
+            "01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000"
+        )
     }
 
     @Test
@@ -95,7 +99,7 @@ class SegwitTestsCommon {
             pversion
         )
         assertTrue(tx1.hasWitness)
-        assertTrue(tx1.txIn.find { it.signatureScript.size() > 0 } == null)
+        assertNull(tx1.txIn.find { it.signatureScript.size() > 0 })
         //assert(tx1.txIn.find(!_.signatureScript.isEmpty).isEmpty)
         val tx2 = tx1.updateWitnesses(listOf(ScriptWitness.empty))
         assertTrue(tx2 != tx1)
@@ -124,13 +128,14 @@ class SegwitTestsCommon {
         val pub1 = priv1.publicKey()
         val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, pub1.hash160())
 
-        assertTrue(address1 == "mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA")
+        assertEquals(address1, "mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA")
 
         // this is a standard tx that sends 0.04 BTC to mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA
         val tx1 = Transaction.read(
             "02000000000101516508384a3e006340f1ea700eb3635330beed5d94c7b460b6b495eb1593d55c0100000023220020a5fdf5b5f2c592362b78a50997821964b39dd90476c6e1f3e97e79acb134ca3bfdffffff0200093d00000000001976a9145dbf52b8d7af4fb5f9b75b808f0a8284493531b388aca005071d0000000017a914d77e5f7ca4d9f05dc4f25dc0aa1391f0e901bdfc87040047304402207bfb18327be173512f38bd4120b8f02545321ecc6105a852cbc25b1de687ba570220705a1225d8a8e0fbd4b35f3bc38a2840706f8524e8dc6f0151746aeff14033ce014730440220486925fb0495442e4ccb1b711692af7057d4db24f8775b5dfa3f8c74992081f102203beae7d96423e0c66b7b5f8919a5f3ad89a42dc4303f37201e4e596909478357014752210245119449d07c16992c148e3b33f1395ee05c936fc510d9fae83417f8e1901f922103eb03f67b56c88bccff90b76182c08556eac9ebc5a0efee8669bef69ae6d4ea5752ae75bb2300",
             pversion
         )
+        assertNull(Script.pay2trOutputKey(tx1.txOut[0].publicKeyScript))
 
         // now let's create a simple tx that spends tx1 and send 0.039 BTC to P2WPK output
         val tx2 = run {
@@ -218,6 +223,7 @@ class SegwitTestsCommon {
             "020000000001016ecc08b535a0c774234419dee508867ace1535a0d256d6b2aa19942441777336000000002322002073bb471aa121fbdd95942eabb5e665d66e71542e6e075c8392cd0df72a075b72fdffffff02803823030000000017a914d3c15be7951c9de644bdf9e22dcbcb77550c4ae487404b4c00000000001976a9143545b2a6659dbe5bdf841d1158135be184d81d3688ac0400473044022041cac92405e4e3215c2f9c27a67ff0792c8fb76e4182023fed081f541f4563e002203bd04d4d810ef8074aeb26a19e01e1ee1a40ad83e4d0ac2c614b8cb22825d2ae0147304402204c947b46ea480419c04098a56a5219bb1f491b07e12926fb6f304132a1f1e29e022078cc9f004c74d6c3c2b2dfcca6385d2fabe44d4eadb027a0d764e1ab9d7f09190147522102be608bf8904326b4d0ec9346aa348773fe51ee70338849acd2dd710b73bf611a2103627c19e40f67c5ee8b44df85ee911b7e978869fa5a3de1d972a461f47ea349e452ae90bb2300",
             pversion
         )
+        assertNull(Script.pay2trOutputKey(tx1.txOut[0].publicKeyScript))
 
         // now let's create a simple tx that spends tx1 and sends 0.049 BTC to a P2WSH output
         val tx2 = run {
@@ -293,7 +299,7 @@ class SegwitTestsCommon {
 
         // which we embed into a standard p2sh script
         val p2shaddress = Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))
-        assertTrue(p2shaddress == "2NB3GUVxBF3P7NLMkSGNai33mWkM35ht1Xj")
+        assertEquals(p2shaddress, "2NB3GUVxBF3P7NLMkSGNai33mWkM35ht1Xj")
 
         // this tx sends 0.05 btc to our p2sh address
         val tx = Transaction.read(

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/TaprootTestsCommon.kt
@@ -60,6 +60,7 @@ class TaprootTestsCommon {
             "02000000000101590c995983abb86d8196f57357f2aac0e6cc6144d8239fd8a171810b476269d50000000000feffffff02a086010000000000225120bfef0f753700ac863e748f8d02c4b0d1fc7569933fd55fb6c3c598e84ff28b7c13d3abe65a060000160014353b5487959c58f5feafe63800057899f9ece4280247304402200b20c43175358c970850a583fd60d36c06588f1103b82b0968dc21e20e7d7958022027c64923623205c4985541d4a9fc6b5df4111d918fe63803337538b029c17ea20121022f685476d299e7b49d3a6b380e10aec1f93d96819fd7697669fabb533cc052624ff50000"
         )
         assertTrue(Script.isPay2tr(tx.txOut[0].publicKeyScript))
+        assertEquals(outputKey, Script.pay2trOutputKey(tx.txOut[0].publicKeyScript))
         assertEquals(script, Script.parse(tx.txOut[0].publicKeyScript))
 
         // tx1 spends tx using key path spending i.e its witness just includes a single signature that is valid for outputKey
@@ -256,6 +257,7 @@ class TaprootTestsCommon {
 
         // this is the tapscript we send funds to
         val script = Script.pay2tr(internalPubkey, scriptTree)
+        assertEquals(tweakedKey, Script.pay2trOutputKey(script))
         val bip350Address = Bech32.encodeWitnessAddress(hrp(blockchain), 1.toByte(), tweakedKey.value.toByteArray())
         assertEquals(bip350Address, "tb1p78gx95syx0qz8w5nftk8t7nce78zlpqpsxugcvq5xpfy4tvn6rasd7wk0y")
         val sweepPublicKeyScript = addressToPublicKeyScript(blockchain, "tb1qxy9hhxkw7gt76qrm4yzw4j06gkk4evryh8ayp7").right!!

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
@@ -529,11 +529,11 @@ class Musig2TestsCommon {
             val (nonce1, publicNonce1) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv1), publicKeys, msg, null)
             val (nonce2, publicNonce2) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv2), publicKeys, msg, null)
             val publicNonces = listOf(publicNonce1, publicNonce2)
-            val sig1 = Musig2.signMessage(priv1, nonce1, msg, publicKeys, publicNonces).right
+            val sig1 = Musig2.sign(priv1, nonce1, msg, publicKeys, publicNonces).right
             assertNotNull(sig1)
             assertTrue(Musig2.verify(sig1, publicNonce1, priv1.publicKey(), msg, publicKeys, publicNonces))
             assertFalse(Musig2.verify(sig1, publicNonce2, priv1.publicKey(), msg, publicKeys, publicNonces))
-            val sig2 = Musig2.signMessage(priv2, nonce2, msg, publicKeys, publicNonces).right
+            val sig2 = Musig2.sign(priv2, nonce2, msg, publicKeys, publicNonces).right
             assertNotNull(sig2)
             assertTrue(Musig2.verify(sig2, publicNonce2, priv2.publicKey(), msg, publicKeys, publicNonces))
             assertFalse(Musig2.verify(sig2, publicNonce2, priv1.publicKey(), msg, publicKeys, publicNonces))
@@ -548,13 +548,13 @@ class Musig2TestsCommon {
             val (nonce2, publicNonce2) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv2), publicKeys, msg, null)
             val (nonce3, publicNonce3) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv3), publicKeys, msg, null)
             val publicNonces = listOf(publicNonce1, publicNonce2, publicNonce3)
-            val sig1 = Musig2.signMessage(priv1, nonce1, msg, publicKeys, publicNonces).right
+            val sig1 = Musig2.sign(priv1, nonce1, msg, publicKeys, publicNonces).right
             assertNotNull(sig1)
             assertTrue(Musig2.verify(sig1, publicNonce1, priv1.publicKey(), msg, publicKeys, publicNonces))
-            val sig2 = Musig2.signMessage(priv2, nonce2, msg, publicKeys, publicNonces).right
+            val sig2 = Musig2.sign(priv2, nonce2, msg, publicKeys, publicNonces).right
             assertNotNull(sig2)
             assertTrue(Musig2.verify(sig2, publicNonce2, priv2.publicKey(), msg, publicKeys, publicNonces))
-            val sig3 = Musig2.signMessage(priv3, nonce3, msg, publicKeys, publicNonces).right
+            val sig3 = Musig2.sign(priv3, nonce3, msg, publicKeys, publicNonces).right
             assertNotNull(sig3)
             assertTrue(Musig2.verify(sig3, publicNonce3, priv3.publicKey(), msg, publicKeys, publicNonces))
             // We can partially aggregate signatures, but it doesn't create a valid schnorr signature for the aggregated public key.
@@ -577,16 +577,16 @@ class Musig2TestsCommon {
             val (nonce3, publicNonce3) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv3), publicKeys, msg, null)
             val (nonce4, publicNonce4) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv4), publicKeys, msg, null)
             val publicNonces = listOf(publicNonce1, publicNonce2, publicNonce3, publicNonce4)
-            val sig1 = Musig2.signMessage(priv1, nonce1, msg, publicKeys, publicNonces).right
+            val sig1 = Musig2.sign(priv1, nonce1, msg, publicKeys, publicNonces).right
             assertNotNull(sig1)
             assertTrue(Musig2.verify(sig1, publicNonce1, priv1.publicKey(), msg, publicKeys, publicNonces))
-            val sig2 = Musig2.signMessage(priv2, nonce2, msg, publicKeys, publicNonces).right
+            val sig2 = Musig2.sign(priv2, nonce2, msg, publicKeys, publicNonces).right
             assertNotNull(sig2)
             assertTrue(Musig2.verify(sig2, publicNonce2, priv2.publicKey(), msg, publicKeys, publicNonces))
-            val sig3 = Musig2.signMessage(priv3, nonce3, msg, publicKeys, publicNonces).right
+            val sig3 = Musig2.sign(priv3, nonce3, msg, publicKeys, publicNonces).right
             assertNotNull(sig3)
             assertTrue(Musig2.verify(sig3, publicNonce3, priv3.publicKey(), msg, publicKeys, publicNonces))
-            val sig4 = Musig2.signMessage(priv4, nonce4, msg, publicKeys, publicNonces).right
+            val sig4 = Musig2.sign(priv4, nonce4, msg, publicKeys, publicNonces).right
             assertNotNull(sig4)
             assertTrue(Musig2.verify(sig4, publicNonce4, priv4.publicKey(), msg, publicKeys, publicNonces))
             // We can partially aggregate signatures, but it doesn't create a valid schnorr signature for the aggregated public key.

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/crypto/musig2/Musig2TestsCommon.kt
@@ -280,14 +280,14 @@ class Musig2TestsCommon {
         val (_, keyAggCache) = KeyAggCache.create(pubkeys)
 
         val (aliceSecNonce, alicePubNonce) = SecretNonce.generate(
-            Random.Default.nextBytes(32).byteVector32(),
+            Random.nextBytes(32).byteVector32(),
             Either.Left(alicePrivKey),
             null,
             keyAggCache,
             null
         )
         val (_, bobPubNonce) = SecretNonce.generate(
-            Random.Default.nextBytes(32).byteVector32(),
+            Random.nextBytes(32).byteVector32(),
             Either.Left(bobPrivKey),
             null,
             keyAggCache,
@@ -317,8 +317,8 @@ class Musig2TestsCommon {
         val tx = Transaction(2, listOf(), listOf(TxOut(10_000.sat(), Script.pay2tr(internalPubKey, Crypto.TaprootTweak.KeyPathTweak))), 0)
         val spendingTx = Transaction(2, listOf(TxIn(OutPoint(tx, 0), sequence = 0)), listOf(TxOut(10_000.sat(), Script.pay2wpkh(alicePubKey))), 0)
 
-        val aliceNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(alicePrivKey), listOf(alicePubKey, bobPubKey), null, null)
-        val bobNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(bobPrivKey), listOf(alicePubKey, bobPubKey), null, null)
+        val aliceNonce = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(alicePrivKey), listOf(alicePubKey, bobPubKey), null, null)
+        val bobNonce = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(bobPrivKey), listOf(alicePubKey, bobPubKey), null, null)
         val publicNonces = listOf(aliceNonce.second, bobNonce.second)
 
         val firstSig = Musig2.signTaprootInput(alicePrivKey, spendingTx, 0, listOf(tx.txOut[0]), listOf(alicePubKey, bobPubKey), aliceNonce.first, publicNonces, scriptTree = null)
@@ -332,7 +332,7 @@ class Musig2TestsCommon {
 
     @Test
     fun `simple musig2 example`() {
-        val msg = Random.Default.nextBytes(32).byteVector32()
+        val msg = Random.nextBytes(32).byteVector32()
         val privkeys = listOf(
             PrivateKey(ByteArray(32) { 1 }),
             PrivateKey(ByteArray(32) { 2 }),
@@ -351,7 +351,7 @@ class Musig2TestsCommon {
         }
 
         // Generate secret nonces for each participant.
-        val nonces = privkeys.map { SecretNonce.generate(Random.Default.nextBytes(32).byteVector32(), Either.Left(it), message = null, keyAggCache, extraInput = null) }
+        val nonces = privkeys.map { SecretNonce.generate(Random.nextBytes(32).byteVector32(), Either.Left(it), message = null, keyAggCache, extraInput = null) }
         val secnonces = nonces.map { it.first }
         val pubnonces = nonces.map { it.second }
 
@@ -380,7 +380,6 @@ class Musig2TestsCommon {
 
         // Alice and Bob exchange public keys and agree on a common aggregated key.
         val internalPubKey = Musig2.aggregateKeys(listOf(alicePubKey, bobPubKey))
-        val commonPubKey = internalPubKey.outputKey(Crypto.TaprootTweak.KeyPathTweak).first
 
         // This tx sends to a taproot script that doesn't contain any script path.
         val tx = Transaction(2, listOf(), listOf(TxOut(10_000.sat(), Script.pay2tr(internalPubKey, Crypto.TaprootTweak.KeyPathTweak))), 0)
@@ -389,8 +388,8 @@ class Musig2TestsCommon {
 
         // The first step of a musig2 signing session is to exchange nonces.
         // If participants are disconnected before the end of the signing session, they must start again with fresh nonces.
-        val aliceNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(alicePrivKey), listOf(alicePubKey, bobPubKey), null, null)
-        val bobNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(bobPrivKey), listOf(alicePubKey, bobPubKey), null, null)
+        val aliceNonce = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(alicePrivKey), listOf(alicePubKey, bobPubKey), null, null)
+        val bobNonce = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(bobPrivKey), listOf(alicePubKey, bobPubKey), null, null)
 
         // Once they have each other's public nonce, they can produce partial signatures.
         val publicNonces = listOf(aliceNonce.second, bobNonce.second)
@@ -398,7 +397,6 @@ class Musig2TestsCommon {
         val aliceSig = Musig2.signTaprootInput(alicePrivKey, spendingTx, 0, listOf(tx.txOut[0]), listOf(alicePubKey, bobPubKey), aliceNonce.first, publicNonces, scriptTree = null).right
         assertNotNull(aliceSig)
         assertTrue(Musig2.verify(aliceSig, aliceNonce.second, alicePubKey, spendingTx, 0, listOf(tx.txOut[0]), listOf(alicePubKey, bobPubKey), publicNonces, scriptTree = null))
-
 
         val bobSig = Musig2.signTaprootInput(bobPrivKey, spendingTx, 0, listOf(tx.txOut[0]), listOf(alicePubKey, bobPubKey), bobNonce.first, publicNonces, scriptTree = null).right
         assertNotNull(bobSig)
@@ -422,13 +420,12 @@ class Musig2TestsCommon {
 
         // Alice and Bob exchange public keys and agree on a common aggregated key.
         val internalPubKey = Musig2.aggregateKeys(listOf(alicePubKey, bobPubKey))
-        val commonPubKey = internalPubKey.outputKey(Crypto.TaprootTweak.KeyPathTweak).first
 
         val tx = Transaction(2, listOf(), listOf(TxOut(10_000.sat(), Script.pay2tr(internalPubKey, Crypto.TaprootTweak.KeyPathTweak))), 0)
         val spendingTx = Transaction(2, listOf(TxIn(OutPoint(tx, 0), sequence = 0)), listOf(TxOut(10_000.sat(), Script.pay2wpkh(alicePubKey))), 0)
 
-        val aliceNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(alicePrivKey), listOf(alicePubKey, bobPubKey), null, null)
-        val bobNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(bobPrivKey), listOf(alicePubKey, bobPubKey), null, null)
+        val aliceNonce = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(alicePrivKey), listOf(alicePubKey, bobPubKey), null, null)
+        val bobNonce = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(bobPrivKey), listOf(alicePubKey, bobPubKey), null, null)
         val publicNonces = listOf(aliceNonce.second, bobNonce.second)
 
         val aliceSig = Musig2.signTaprootInput(alicePrivKey, spendingTx, 0, listOf(tx.txOut[0]), listOf(alicePubKey, bobPubKey), aliceNonce.first, publicNonces, scriptTree = null).right
@@ -484,8 +481,8 @@ class Musig2TestsCommon {
             )
             // The first step of a musig2 signing session is to exchange nonces.
             // If participants are disconnected before the end of the signing session, they must start again with fresh nonces.
-            val userNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(userPrivateKey), listOf(userPublicKey, serverPublicKey), null, null)
-            val serverNonce = Musig2.generateNonce(Random.Default.nextBytes(32).byteVector32(), Either.Left(serverPrivateKey), listOf(userPublicKey, serverPublicKey), null, null)
+            val userNonce = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(userPrivateKey), listOf(userPublicKey, serverPublicKey), null, null)
+            val serverNonce = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(serverPrivateKey), listOf(userPublicKey, serverPublicKey), null, null)
 
             // Once they have each other's public nonce, they can produce partial signatures.
             val publicNonces = listOf(userNonce.second, serverNonce.second)
@@ -515,6 +512,94 @@ class Musig2TestsCommon {
             val sig = Transaction.signInputTaprootScriptPath(userRefundPrivateKey, tx, 0, swapInTx.txOut, SigHash.SIGHASH_DEFAULT, scriptTree.hash())
             val signedTx = tx.updateWitness(0, Script.witnessScriptPathPay2tr(internalPubKey, scriptTree, ScriptWitness(listOf(sig)), scriptTree))
             Transaction.correctlySpends(signedTx, swapInTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+        }
+    }
+
+    @Test
+    fun `sign arbitrary messages with musig2`() {
+        val priv1 = PrivateKey(Random.nextBytes(32))
+        val priv2 = PrivateKey(Random.nextBytes(32))
+        val priv3 = PrivateKey(Random.nextBytes(32))
+        val priv4 = PrivateKey(Random.nextBytes(32))
+        val msg = Random.nextBytes(32).byteVector32()
+
+        // 2-of-2 signatures:
+        run {
+            val publicKeys = listOf(priv1.publicKey(), priv2.publicKey())
+            val (nonce1, publicNonce1) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv1), publicKeys, msg, null)
+            val (nonce2, publicNonce2) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv2), publicKeys, msg, null)
+            val publicNonces = listOf(publicNonce1, publicNonce2)
+            val sig1 = Musig2.signMessage(priv1, nonce1, msg, publicKeys, publicNonces).right
+            assertNotNull(sig1)
+            assertTrue(Musig2.verify(sig1, publicNonce1, priv1.publicKey(), msg, publicKeys, publicNonces))
+            assertFalse(Musig2.verify(sig1, publicNonce2, priv1.publicKey(), msg, publicKeys, publicNonces))
+            val sig2 = Musig2.signMessage(priv2, nonce2, msg, publicKeys, publicNonces).right
+            assertNotNull(sig2)
+            assertTrue(Musig2.verify(sig2, publicNonce2, priv2.publicKey(), msg, publicKeys, publicNonces))
+            assertFalse(Musig2.verify(sig2, publicNonce2, priv1.publicKey(), msg, publicKeys, publicNonces))
+            val sig = Musig2.aggregatePartialSignatures(listOf(sig1, sig2), msg, publicKeys, publicNonces).right
+            assertNotNull(sig)
+            assertTrue(Crypto.verifySignatureSchnorr(msg, sig, Musig2.aggregateKeys(publicKeys)))
+        }
+        // 3-of-3 signatures:
+        run {
+            val publicKeys = listOf(priv1.publicKey(), priv2.publicKey(), priv3.publicKey())
+            val (nonce1, publicNonce1) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv1), publicKeys, msg, null)
+            val (nonce2, publicNonce2) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv2), publicKeys, msg, null)
+            val (nonce3, publicNonce3) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv3), publicKeys, msg, null)
+            val publicNonces = listOf(publicNonce1, publicNonce2, publicNonce3)
+            val sig1 = Musig2.signMessage(priv1, nonce1, msg, publicKeys, publicNonces).right
+            assertNotNull(sig1)
+            assertTrue(Musig2.verify(sig1, publicNonce1, priv1.publicKey(), msg, publicKeys, publicNonces))
+            val sig2 = Musig2.signMessage(priv2, nonce2, msg, publicKeys, publicNonces).right
+            assertNotNull(sig2)
+            assertTrue(Musig2.verify(sig2, publicNonce2, priv2.publicKey(), msg, publicKeys, publicNonces))
+            val sig3 = Musig2.signMessage(priv3, nonce3, msg, publicKeys, publicNonces).right
+            assertNotNull(sig3)
+            assertTrue(Musig2.verify(sig3, publicNonce3, priv3.publicKey(), msg, publicKeys, publicNonces))
+            // We can partially aggregate signatures, but it doesn't create a valid schnorr signature for the aggregated public key.
+            val incompleteSig = Musig2.aggregatePartialSignatures(listOf(sig1, sig2), msg, publicKeys, publicNonces).right
+            assertNotNull(incompleteSig)
+            assertFalse(Crypto.verifySignatureSchnorr(msg, incompleteSig, Musig2.aggregateKeys(publicKeys)))
+            // Including redundant partial signatures doesn't yield a valid signature.
+            val redundantSig = Musig2.aggregatePartialSignatures(listOf(sig1, sig2, sig1), msg, publicKeys, publicNonces).right
+            assertNotNull(redundantSig)
+            assertFalse(Crypto.verifySignatureSchnorr(msg, redundantSig, Musig2.aggregateKeys(publicKeys)))
+            val sig = Musig2.aggregatePartialSignatures(listOf(sig1, sig2, sig3), msg, publicKeys, publicNonces).right
+            assertNotNull(sig)
+            assertTrue(Crypto.verifySignatureSchnorr(msg, sig, Musig2.aggregateKeys(publicKeys)))
+        }
+        // 4-of-4 signatures:
+        run {
+            val publicKeys = listOf(priv1.publicKey(), priv2.publicKey(), priv3.publicKey(), priv4.publicKey())
+            val (nonce1, publicNonce1) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv1), publicKeys, msg, null)
+            val (nonce2, publicNonce2) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv2), publicKeys, msg, null)
+            val (nonce3, publicNonce3) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv3), publicKeys, msg, null)
+            val (nonce4, publicNonce4) = Musig2.generateNonce(Random.nextBytes(32).byteVector32(), Either.Left(priv4), publicKeys, msg, null)
+            val publicNonces = listOf(publicNonce1, publicNonce2, publicNonce3, publicNonce4)
+            val sig1 = Musig2.signMessage(priv1, nonce1, msg, publicKeys, publicNonces).right
+            assertNotNull(sig1)
+            assertTrue(Musig2.verify(sig1, publicNonce1, priv1.publicKey(), msg, publicKeys, publicNonces))
+            val sig2 = Musig2.signMessage(priv2, nonce2, msg, publicKeys, publicNonces).right
+            assertNotNull(sig2)
+            assertTrue(Musig2.verify(sig2, publicNonce2, priv2.publicKey(), msg, publicKeys, publicNonces))
+            val sig3 = Musig2.signMessage(priv3, nonce3, msg, publicKeys, publicNonces).right
+            assertNotNull(sig3)
+            assertTrue(Musig2.verify(sig3, publicNonce3, priv3.publicKey(), msg, publicKeys, publicNonces))
+            val sig4 = Musig2.signMessage(priv4, nonce4, msg, publicKeys, publicNonces).right
+            assertNotNull(sig4)
+            assertTrue(Musig2.verify(sig4, publicNonce4, priv4.publicKey(), msg, publicKeys, publicNonces))
+            // We can partially aggregate signatures, but it doesn't create a valid schnorr signature for the aggregated public key.
+            val incompleteSig = Musig2.aggregatePartialSignatures(listOf(sig1, sig2, sig3), msg, publicKeys, publicNonces).right
+            assertNotNull(incompleteSig)
+            assertFalse(Crypto.verifySignatureSchnorr(msg, incompleteSig, Musig2.aggregateKeys(publicKeys)))
+            // Including redundant partial signatures doesn't yield a valid signature.
+            val redundantSig = Musig2.aggregatePartialSignatures(listOf(sig1, sig2, sig2, sig4), msg, publicKeys, publicNonces).right
+            assertNotNull(redundantSig)
+            assertFalse(Crypto.verifySignatureSchnorr(msg, redundantSig, Musig2.aggregateKeys(publicKeys)))
+            val sig = Musig2.aggregatePartialSignatures(listOf(sig1, sig2, sig3, sig4), msg, publicKeys, publicNonces).right
+            assertNotNull(sig)
+            assertTrue(Crypto.verifySignatureSchnorr(msg, sig, Musig2.aggregateKeys(publicKeys)))
         }
     }
 }


### PR DESCRIPTION
We add several helpers that become useful when implementing support for taproot gossip to verify channel announcements: see https://github.com/ellemouton/bolts/blob/bolt-taproot-gossip/bolt-taproot-gossip.md#taproot-channel-proof-and-verification for more details.

Each commit adds separate helpers:

- a helper function to extract the output key of a p2tr output
- high-level musig2 functions to sign arbitrary messages