### PR TITLE
fix: Generate BIP32 key fingerprints as 4 byte hex strings

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/DeterministicWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/DeterministicWallet.kt
@@ -103,6 +103,11 @@ public object DeterministicWallet {
         public fun fingerprint(): Long = extendedPublicKey.fingerprint()
 
         /**
+         * @return the fingerprint for this private key as a 4 byte hex string
+         */
+        public fun keyFingerprint(): String = extendedPublicKey.keyFingerprint()
+
+        /**
          * We avoid accidentally logging extended private keys.
          * You should use an explicit method if you want to convert the extended private key to a string representation.
          */
@@ -164,7 +169,7 @@ public object DeterministicWallet {
                 chaincode = IR.byteVector32(),
                 depth = depth + 1,
                 path = path.derive(index),
-                parent = fingerprint()
+                parent = keyFingerprint().toLong(16)
             )
         }
 
@@ -175,6 +180,11 @@ public object DeterministicWallet {
         public fun derivePublicKey(keyPath: String): ExtendedPublicKey = derivePublicKey(KeyPath.fromPath(keyPath))
 
         public fun fingerprint(): Long = Pack.int32LE(ByteArrayInput(Crypto.hash160(publickeybytes).take(4).reversed().toByteArray())).toLong()
+
+        /**
+         * @return the fingerprint for this public key as a 4 byte hex string
+         */
+        public fun keyFingerprint(): String = Crypto.hash160(publickeybytes).take(4).toByteArray().toHexString()
 
         public fun encode(prefix: Int): String {
             val out = ByteArrayOutput()
@@ -258,6 +268,13 @@ public object DeterministicWallet {
      */
     @JvmStatic
     public fun fingerprint(input: ExtendedPublicKey): Long = input.fingerprint()
+
+    /**
+     * @param input extended public key
+     * @return the fingerprint for this public key as a 4 byte hex string
+     */
+    @JvmStatic
+    public fun keyFingerprint(input: ExtendedPublicKey): String = input.keyFingerprint()
 
     /**
      * @param input extended private key

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/reference/BIP32KeyFingerprintTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/reference/BIP32KeyFingerprintTestsCommon.kt
@@ -1,0 +1,43 @@
+package fr.acinq.bitcoin.reference
+
+import fr.acinq.bitcoin.DeterministicWallet
+import fr.acinq.bitcoin.MnemonicCode.toSeed
+import fr.acinq.bitcoin.TestHelpers
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class BIP32KeyFingerprintTestsCommon {
+    @Test
+    fun `verify key fingerprints for all bip39 test vectors`() {
+        val tests = TestHelpers.readResourceAsJson("bip39_vectors.json")
+
+        tests.jsonObject["english"]!!.jsonArray.forEach {
+            val mnemonics = it.jsonArray[1].jsonPrimitive.content
+            val seed = toSeed(mnemonics, "")
+            val masterKey = DeterministicWallet.generate(seed)
+            val fingerprint = masterKey.keyFingerprint()
+            assertEquals(8, fingerprint.length)
+        }
+    }
+
+    /**
+     * Use this to reproduce the bug in [DeterministicWallet.ExtendedPublicKey.fingerprint]
+     */
+    @Test
+    fun `fail verifying key fingerprints with negative fingerprint from bip39 test vectors`() {
+        val tests = TestHelpers.readResourceAsJson("bip39_vectors.json")
+
+        tests.jsonObject["english"]!!.jsonArray.forEach {
+            val mnemonics = it.jsonArray[1].jsonPrimitive.content
+            val seed = toSeed(mnemonics, "")
+            val masterKey = DeterministicWallet.generate(seed)
+            val fingerprint = masterKey.fingerprint().toString(16).padStart(8, '0')
+            if (fingerprint.length == 8) return@forEach
+            assertNotEquals(8, fingerprint.length)
+        }
+    }
+}


### PR DESCRIPTION
@sstone @t-bast 

Currently the function `fingerprint` return `Long` and somehow from byte level computation it returns invalid fingerprints for some keys. So lucky, this can be verified with BIP39 test vectors. 
You can reproduce this by running the tests in `BIP32KeyFingerprintTestsCommon`

The provided fix is in function `keyFingerprint` which returns the fingerprint as an exactly 4 byte hex string, it can be converted to `Long` by `toLong` with radix `16` for any usages that require `Long` fingerprints.