### PR TITLE
Performance improvements 

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/LexicographicalOrdering.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/LexicographicalOrdering.kt
@@ -23,14 +23,14 @@ import kotlin.jvm.JvmStatic
  * See https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki
  */
 public object LexicographicalOrdering {
-    private tailrec fun isLessThanInternal(a: ByteArray, b: ByteArray): Boolean {
-        return when {
-            a.isEmpty() && b.isEmpty() -> false
-            a.isEmpty() -> true
-            b.isEmpty() -> false
-            a.first() == b.first() -> isLessThanInternal(a.drop(1).toByteArray(), b.drop(1).toByteArray())
-            else -> (a.first().toInt() and 0xff) < (b.first().toInt() and 0xff)
+    private fun isLessThanInternal(a: ByteArray, b: ByteArray): Boolean {
+        val len = minOf(a.size, b.size)
+        for (i in 0 until len) {
+            val ai = a[i].toInt() and 0xff
+            val bi = b[i].toInt() and 0xff
+            if (ai != bi) return ai < bi
         }
+        return a.size < b.size
     }
 
     @JvmStatic

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
@@ -20,6 +20,7 @@ import fr.acinq.bitcoin.BtcSerializer.Companion.writeScript
 import fr.acinq.bitcoin.BtcSerializer.Companion.writeUInt32
 import fr.acinq.bitcoin.BtcSerializer.Companion.writeUInt64
 import fr.acinq.bitcoin.Protocol.PROTOCOL_VERSION
+import fr.acinq.bitcoin.crypto.Digest
 import fr.acinq.bitcoin.io.ByteArrayOutput
 import fr.acinq.bitcoin.io.Input
 import fr.acinq.bitcoin.io.Output
@@ -87,7 +88,7 @@ public data class OutPoint(@JvmField val hash: TxHash, @JvmField val index: Long
 
         @JvmStatic
         override fun write(message: OutPoint, out: Output, protocolVersion: Long) {
-            out.write(message.hash.value.toByteArray())
+            out.write(message.hash.value)
             writeUInt32(message.index.toUInt(), out)
         }
 
@@ -260,7 +261,7 @@ public data class TxOut(@JvmField val amount: Satoshi, @JvmField val publicKeySc
 
     public fun updatePublicKeyScript(input: List<ScriptElt>): TxOut = updatePublicKeyScript(Script.write(input))
 
-    public fun totalSize(): Int = Companion.totalSize(this)
+    public fun totalSize(): Int = totalSize(this)
 
     public fun weight(): Int = weight(this)
 
@@ -309,10 +310,55 @@ public data class Transaction(
     @JvmField val lockTime: Long
 ) : BtcSerializable<Transaction> {
 
+    private val hashPrevOut: ByteArray by lazy {
+        Crypto.sha256(prevoutsSha256)
+    }
+
+    private val hashSequence: ByteArray by lazy {
+        Crypto.sha256(sequencesSha256)
+    }
+
+    private val hashOutputs: ByteArray by lazy {
+        Crypto.sha256(outputsSha256)
+    }
+
+    internal val prevoutsSha256: ByteArray by lazy {
+        val sha256 = Digest.sha256()
+        txIn.forEach {
+            val buffer = OutPoint.write(it.outPoint, PROTOCOL_VERSION)
+            sha256.update(buffer, 0, buffer.size)
+        }
+        val result = ByteArray(32)
+        sha256.doFinal(result, 0)
+        result
+    }
+
+    internal val sequencesSha256: ByteArray by lazy {
+        val sha256 = Digest.sha256()
+        txIn.forEach {
+            val buffer = writeUInt32(it.sequence.toUInt())
+            sha256.update(buffer, 0, buffer.size)
+        }
+        val result = ByteArray(32)
+        sha256.doFinal(result, 0)
+        result
+    }
+
+    internal val outputsSha256: ByteArray by lazy {
+        val sha256 = Digest.sha256()
+        txOut.forEach {
+            val buffer = TxOut.write(it, PROTOCOL_VERSION)
+            sha256.update(buffer, 0, buffer.size)
+        }
+        val result = ByteArray(32)
+        sha256.doFinal(result, 0)
+        result
+    }
+
     public val hasWitness: Boolean get() = txIn.any { it.hasWitness }
 
     @JvmField
-    public val hash: TxHash = TxHash(Crypto.hash256(Transaction.write(this, SERIALIZE_TRANSACTION_NO_WITNESS)))
+    public val hash: TxHash = TxHash(Crypto.hash256(write(this, SERIALIZE_TRANSACTION_NO_WITNESS)))
 
     @JvmField
     public val txid: TxId = TxId(hash)
@@ -404,14 +450,14 @@ public data class Transaction(
         writeUInt32(lockTime.toUInt(), out)
         val inputType = sighashType and SigHash.SIGHASH_INPUT_MASK
         if (inputType != SigHash.SIGHASH_ANYONECANPAY) {
-            out.write(prevoutsSha256(this))
+            out.write(this.prevoutsSha256)
             out.write(amountsSha256(inputs))
             out.write(scriptPubkeysSha256(inputs))
-            out.write(sequencesSha256(this))
+            out.write(this.sequencesSha256)
         }
         val outputType = if (sighashType == SigHash.SIGHASH_DEFAULT) SigHash.SIGHASH_ALL else sighashType and SigHash.SIGHASH_OUTPUT_MASK
         if (outputType == SigHash.SIGHASH_ALL) {
-            out.write(outputsSha256(this))
+            out.write(this.outputsSha256)
         }
         return out.toByteArray()
     }
@@ -482,7 +528,7 @@ public data class Transaction(
             ByteVector32.One.toByteArray()
         } else {
             val txCopy = prepareForSigning(inputIndex, previousOutputScript, sighashType)
-            Crypto.hash256(Transaction.write(txCopy, SERIALIZE_TRANSACTION_NO_WITNESS) + writeUInt32(sighashType.toUInt()))
+            Crypto.hash256(write(txCopy, SERIALIZE_TRANSACTION_NO_WITNESS) + writeUInt32(sighashType.toUInt()))
         }
     }
 
@@ -499,21 +545,15 @@ public data class Transaction(
         when (signatureVersion) {
             SigVersion.SIGVERSION_WITNESS_V0 -> {
                 val hashPrevOut = if (!SigHash.isAnyoneCanPay(sighashType)) {
-                    val arrays = txIn.map { it.outPoint }.map { OutPoint.write(it, PROTOCOL_VERSION) }
-                    val concatenated = arrays.fold(ByteArray(0)) { acc, b -> acc + b }
-                    Crypto.hash256(concatenated)
+                    this.hashPrevOut
                 } else ByteArray(32)
 
                 val hashSequence = if (!SigHash.isAnyoneCanPay(sighashType) && !SigHash.isHashSingle(sighashType) && !SigHash.isHashNone(sighashType)) {
-                    val arrays = txIn.map { it.sequence }.map { writeUInt32(it.toUInt()) }
-                    val concatenated = arrays.fold(ByteArray(0)) { acc, b -> acc + b }
-                    Crypto.hash256(concatenated)
+                    this.hashSequence
                 } else ByteArray(32)
 
                 val hashOutputs = if (!SigHash.isHashSingle(sighashType) && !SigHash.isHashNone(sighashType)) {
-                    val arrays = txOut.map { TxOut.write(it, PROTOCOL_VERSION) }
-                    val concatenated = arrays.fold(ByteArray(0)) { acc, b -> acc + b }
-                    Crypto.hash256(concatenated)
+                    this.hashOutputs
                 } else if (SigHash.isHashSingle(sighashType) && inputIndex < txOut.count()) {
                     Crypto.hash256(TxOut.write(txOut[inputIndex], PROTOCOL_VERSION))
                 } else ByteArray(32)
@@ -695,7 +735,7 @@ public data class Transaction(
         }
         if (sigVersion == SigVersion.SIGVERSION_TAPSCRIPT) {
             require(tapleaf != null) { "tapleaf hash is missing" }
-            out.write(tapleaf.toByteArray())
+            out.write(tapleaf)
             out.write(keyVersion)
             writeUInt32((codeSeparatorPos ?: 0xFFFFFFFFL).toUInt(), out)
         }
@@ -888,13 +928,6 @@ public data class Transaction(
         public fun isCoinbase(input: Transaction): Boolean = input.isCoinbase()
 
         @JvmStatic
-        public fun prevoutsSha256(tx: Transaction): ByteArray {
-            val buffer = ByteArrayOutput()
-            tx.txIn.forEach { OutPoint.write(it.outPoint, buffer) }
-            return Crypto.sha256(buffer.toByteArray())
-        }
-
-        @JvmStatic
         public fun amountsSha256(inputs: List<TxOut>): ByteArray {
             val buffer = ByteArrayOutput()
             inputs.forEach { writeUInt64(it.amount.toULong(), buffer) }
@@ -905,20 +938,6 @@ public data class Transaction(
         public fun scriptPubkeysSha256(inputs: List<TxOut>): ByteArray {
             val buffer = ByteArrayOutput()
             inputs.forEach { writeScript(it.publicKeyScript, buffer) }
-            return Crypto.sha256(buffer.toByteArray())
-        }
-
-        @JvmStatic
-        public fun sequencesSha256(tx: Transaction): ByteArray {
-            val buffer = ByteArrayOutput()
-            tx.txIn.forEach { writeUInt32(it.sequence.toUInt(), buffer) }
-            return Crypto.sha256(buffer.toByteArray())
-        }
-
-        @JvmStatic
-        public fun outputsSha256(tx: Transaction): ByteArray {
-            val buffer = ByteArrayOutput()
-            tx.txOut.forEach { TxOut.write(it, buffer) }
             return Crypto.sha256(buffer.toByteArray())
         }
 

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/Transaction.kt
@@ -310,6 +310,9 @@ public data class Transaction(
     @JvmField val lockTime: Long
 ) : BtcSerializable<Transaction> {
 
+    // the following hashes are used in the computation of the hash that is signed when a specific input is signed
+    // they are independent of the input being signed and can be computed only once, and only when needed
+    // each lazy values adds a memory overhead of a few dozen bytes for the "by lazy" delegate, plus 32 bytes once it has been initialized
     private val hashPrevOut: ByteArray by lazy {
         Crypto.sha256(prevoutsSha256)
     }

--- a/src/commonMain/kotlin/fr/acinq/bitcoin/io/Output.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/io/Output.kt
@@ -16,7 +16,10 @@
 
 package fr.acinq.bitcoin.io
 
+import fr.acinq.bitcoin.ByteVector
+
 public interface Output {
     public fun write(buffer: ByteArray, offset: Int = 0, count: Int = buffer.size)
+    public fun write(buffer: ByteVector): Unit = write(buffer.bytes, buffer.offset, buffer.size())
     public fun write(byteValue: Int)
 }

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/reference/BIP341TestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/reference/BIP341TestsCommon.kt
@@ -39,10 +39,10 @@ class BIP341TestsCommon {
             val hashSequences = it.jsonObject["intermediary"]!!.jsonObject["hashSequences"]!!.jsonPrimitive.content
 
             assertEquals(hashAmounts, Hex.encode(Transaction.amountsSha256(utxosSpent)))
-            assertEquals(hashOutputs, Hex.encode(Transaction.outputsSha256(rawUnsignedTx)))
-            assertEquals(hashPrevouts, Hex.encode(Transaction.prevoutsSha256(rawUnsignedTx)))
+            assertEquals(hashOutputs, Hex.encode(rawUnsignedTx.outputsSha256))
+            assertEquals(hashPrevouts, Hex.encode(rawUnsignedTx.prevoutsSha256))
             assertEquals(hashScriptPubkeys, Hex.encode(Transaction.scriptPubkeysSha256(utxosSpent)))
-            assertEquals(hashSequences, Hex.encode(Transaction.sequencesSha256(rawUnsignedTx)))
+            assertEquals(hashSequences, Hex.encode(rawUnsignedTx.sequencesSha256))
 
             val previousOutputs = (fullySignedTx.txIn.map { it.outPoint }).zip(utxosSpent).toMap()
             Transaction.correctlySpends(fullySignedTx, previousOutputs, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)


### PR DESCRIPTION
Simpler alternative to https://github.com/ACINQ/bitcoin-kmp/pull/183, which keeps improvements on transaction hashing but discard potentially dangerous byte vector optimisations.  