### PR TITLE
Parse the taproot BIP32 derivation fingerprint as an unsigned value

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/bitcoin/psbt/Psbt.kt
+++ b/src/commonMain/kotlin/fr/acinq/bitcoin/psbt/Psbt.kt
@@ -1227,7 +1227,10 @@ public data class TaprootBip32DerivationPath(@JvmField val leaves: List<ByteVect
             val input = ByteArrayInput(bin)
             val numLeaves = BtcSerializer.varint(input).toInt()
             val leaves = (0 until numLeaves).map { BtcSerializer.bytes(input, 32).byteVector32() }
-            val masterKeyFingerprint = Pack.int32BE(input).toLong()
+            // The fingerprint is an unsigned 32-bit value: convert through UInt so that fingerprints whose high bit is
+            // set do not sign-extend into a negative Long. This matches how PSBT_IN_BIP32_DERIVATION and
+            // PSBT_GLOBAL_XPUB fingerprints are parsed elsewhere in this file.
+            val masterKeyFingerprint = Pack.int32BE(input).toUInt().toLong()
             val childCount = (input.availableBytes / 4)
             val keyPath = KeyPath((0 until childCount).map { _ -> Pack.int32LE(input).toUInt().toLong() })
             return TaprootBip32DerivationPath(leaves, masterKeyFingerprint, keyPath)

--- a/src/commonTest/kotlin/fr/acinq/bitcoin/psbt/PsbtTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/bitcoin/psbt/PsbtTestsCommon.kt
@@ -1650,4 +1650,44 @@ class PsbtTestsCommon {
         assertTrue(output.unknown.isEmpty())
     }
 
+    @Test
+    fun `read taproot bip32 derivation with a master fingerprint whose high bit is set`() {
+        // Master key fingerprints are unsigned 32-bit values, so roughly half of all wallets have one whose first byte
+        // is >= 0x80. Sign-extending such a fingerprint yields a negative Long that never compares equal to the
+        // fingerprint a wallet computes for itself, so its own taproot inputs go unrecognized.
+        val fingerprint = 0x8dfc9b34L
+        val path = TaprootBip32DerivationPath(listOf(), fingerprint, KeyPath("m/86'/1'/0'/0/0"))
+        val decoded = TaprootBip32DerivationPath.read(path.write())
+        assertEquals(fingerprint, decoded.masterKeyFingerprint)
+        assertEquals(path.keyPath, decoded.keyPath)
+        assertEquals(path, decoded)
+
+        // And the same through a full PSBT round trip.
+        val seed = ByteVector.fromHex("0101010101010101010101010101010101010101010101010101010101010101")
+        val master = DeterministicWallet.generate(seed)
+        val pub = master.derivePrivateKey("86'/1'/0'/0").extendedPublicKey.derivePublicKey(0).publicKey.xOnly()
+        val utxo = Transaction(
+            version = 2,
+            txIn = listOf(),
+            txOut = listOf(TxOut(100_000.sat(), Script.pay2tr(pub, Crypto.TaprootTweak.KeyPathTweak))),
+            lockTime = 0
+        )
+        val psbt = Psbt(
+            tx = Transaction(
+                version = 2,
+                txIn = listOf(TxIn(OutPoint(utxo, 0), TxIn.SEQUENCE_FINAL)),
+                txOut = listOf(TxOut(90_000.sat(), Script.pay2tr(pub, Crypto.TaprootTweak.KeyPathTweak))),
+                lockTime = 0
+            )
+        ).updateWitnessInput(
+            OutPoint(utxo, 0),
+            utxo.txOut[0],
+            taprootInternalKey = pub,
+            taprootDerivationPaths = mapOf(pub to path)
+        ).right!!
+
+        val reread = Psbt.read(Psbt.write(psbt)).right!!
+        assertEquals(fingerprint, reread.inputs[0].taprootDerivationPaths[pub]!!.masterKeyFingerprint)
+    }
+
 }


### PR DESCRIPTION
`TaprootBip32DerivationPath.read` parses the master key fingerprint with `Pack.int32BE(input).toLong()`, which sign-extends it. The three other fingerprint parse sites in the same file — `PSBT_GLOBAL_XPUB`, `PSBT_IN_BIP32_DERIVATION` and `PSBT_OUT_BIP32_DERIVATION` — all use `.toUInt().toLong()`; only the taproot path differs.

Fingerprints are unsigned 32-bit values, so roughly half have a first byte `>= 0x80`. For those, `PSBT_IN_TAP_BIP32_DERIVATION` decodes to a negative `Long` that never equals the fingerprint a wallet computes for itself, so it doesn't recognise its own taproot inputs. In practice a BIP-86 wallet can't sign its own PSBTs while the same key material signs native segwit PSBTs fine.

The existing taproot-derivation fixtures use fingerprints `0x772b2da7` and `0`, both with the high bit clear, which is why the current suite doesn't catch it. The added test covers the direct `write()`/`read()` round trip and a full `Psbt.write`/`Psbt.read` round trip with fingerprint `0x8dfc9b34`; it fails on master with:

```
java.lang.AssertionError: expected:<2382142260> but was:<-1912825036>
```
